### PR TITLE
feat: update Palworld runtime to v2.5.0

### DIFF
--- a/apps/api/internal/http/server_handlers_test.go
+++ b/apps/api/internal/http/server_handlers_test.go
@@ -451,7 +451,7 @@ func TestCreatePalworldServerUsesPalworldRuntimeSpec(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("expected async start to create runtime container")
 	}
-	if spec.Image != "smartcat99999/palworld-server:v2.4.1" {
+	if spec.Image != "smartcat99999/palworld-server:v2.5.0" {
 		t.Fatalf("expected Palworld image, got %q", spec.Image)
 	}
 	if spec.Port != 8211 || spec.Options.PortProtocol != "udp" {

--- a/apps/api/internal/provider/palworld/provider.go
+++ b/apps/api/internal/provider/palworld/provider.go
@@ -12,7 +12,7 @@ import (
 
 const DefaultInternalPort = 8211
 
-var versions = []string{"v2.4.1", "v2.4.0", "v2.3.2"}
+var versions = []string{"v2.5.0", "v2.4.2", "v2.4.1"}
 
 type Provider struct {
 	runtime runtimecatalog.RuntimeConfig

--- a/apps/api/internal/provider/palworld/provider_test.go
+++ b/apps/api/internal/provider/palworld/provider_test.go
@@ -58,7 +58,7 @@ func TestRuntimeOptionsUsePalworldImageAndUdpPort(t *testing.T) {
 	provider := NewProvider()
 	options := runtimeOptions(config)
 
-	if provider.ImageFor("") != "smartcat99999/palworld-server:v2.4.1" {
+	if provider.ImageFor("") != "smartcat99999/palworld-server:v2.5.0" {
 		t.Fatalf("unexpected Palworld image: %s", provider.ImageFor(""))
 	}
 	if options.PortProtocol != "udp" {

--- a/config/providers.json
+++ b/config/providers.json
@@ -19,7 +19,7 @@
     },
     "palworld": {
       "imageTemplate": "{registry}/palworld-server:{version}",
-      "versions": ["v2.4.1", "v2.4.0", "v2.3.2"]
+      "versions": ["v2.5.0", "v2.4.2", "v2.4.1"]
     },
     "minecraft": {
       "image": "{registry}/minecraft-server:2026.6.0-java21",

--- a/docker/palworld/Dockerfile
+++ b/docker/palworld/Dockerfile
@@ -1,0 +1,6 @@
+ARG PALWORLD_RUNTIME_VERSION=v2.5.0
+FROM thijsvanloef/palworld-server-docker:${PALWORLD_RUNTIME_VERSION}
+
+LABEL org.opencontainers.image.title="GamePanel Lite Palworld Server" \
+      org.opencontainers.image.description="Palworld dedicated server runtime for GamePanel Lite" \
+      org.opencontainers.image.source="https://github.com/smartcat999/game-panel-lite"

--- a/docker/palworld/README.md
+++ b/docker/palworld/README.md
@@ -1,0 +1,21 @@
+# Palworld Server Image
+
+This image packages the stable `thijsvanloef/palworld-server-docker` runtime under the GamePanel Lite image namespace. The runtime installs or updates Palworld Dedicated Server (Steam app `2394010`) when the container starts because the provider sets `UPDATE_ON_BOOT=true`.
+
+Build and load the current version for the local Docker architecture:
+
+```bash
+scripts/build-game-images.sh palworld --load
+```
+
+Build and push both supported architectures:
+
+```bash
+scripts/build-game-images.sh palworld --platform linux/amd64,linux/arm64 --push
+```
+
+Override the upstream runtime tag when testing a newer release:
+
+```bash
+PALWORLD_RUNTIME_VERSION=v2.5.0 scripts/build-game-images.sh palworld --load
+```

--- a/scripts/build-game-images.sh
+++ b/scripts/build-game-images.sh
@@ -6,13 +6,14 @@ usage() {
 Build GamePanel Lite game runtime images.
 
 Usage:
-  scripts/build-game-images.sh [all|vanilla|tmodloader|dst] [options]
+  scripts/build-game-images.sh [all|vanilla|tmodloader|dst|palworld] [options]
 
 Targets:
   all           Build vanilla Terraria and tModLoader images. Default.
   vanilla       Build only vanilla Terraria images.
   tmodloader    Build only tModLoader images.
   dst           Build only Don't Starve Together images. linux/amd64 only.
+  palworld      Build only the Palworld dedicated server image.
 
 Options:
   --registry NAME       Image namespace. Default: smartcat99999
@@ -29,6 +30,7 @@ Examples:
   scripts/build-game-images.sh all --platform linux/amd64,linux/arm64 --push
   scripts/build-game-images.sh dst --platform linux/amd64 --load
   scripts/build-game-images.sh dst --builder amd64-builder --platform linux/amd64 --push
+  scripts/build-game-images.sh palworld --platform linux/amd64,linux/arm64 --push
 USAGE
 }
 
@@ -83,7 +85,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 case "$target" in
-  all|vanilla|tmodloader|dst) ;;
+  all|vanilla|tmodloader|dst|palworld) ;;
   *)
     echo "Unknown target: $target" >&2
     usage >&2
@@ -163,6 +165,18 @@ build_dst() {
     "${root_dir}"
 }
 
+build_palworld() {
+  local version="${PALWORLD_RUNTIME_VERSION:-v2.5.0}"
+  local image="${registry}/palworld-server:${version}"
+
+  echo "==> Building ${image}"
+  docker "${buildx_args[@]}" \
+    -f docker/palworld/Dockerfile \
+    --build-arg "PALWORLD_RUNTIME_VERSION=${version}" \
+    -t "${image}" \
+    "${root_dir}"
+}
+
 cd "$root_dir"
 
 if [[ "$target" == "all" || "$target" == "vanilla" ]]; then
@@ -176,6 +190,10 @@ fi
 
 if [[ "$target" == "dst" ]]; then
   build_dst "v2026.06.21"
+fi
+
+if [[ "$target" == "palworld" ]]; then
+  build_palworld
 fi
 
 echo "Done."


### PR DESCRIPTION
## Summary
- add a first-class Palworld runtime image build target
- update the Palworld runtime catalog default to v2.5.0
- document local and multi-platform image builds

## Published images
- smartcat99999/palworld-server:v2.5.0
- registry.cn-hangzhou.aliyuncs.com/gamepanel-lite/palworld-server:v2.5.0

Both images include linux/amd64 and linux/arm64 manifests.

## Validation
- go test ./... (one unrelated Docker timing test failed once, then passed on retry)
- go test ./apps/api/internal/app
- bash -n scripts/build-game-images.sh
- git diff --check