### PR TITLE
feat: group Palworld settings

### DIFF
--- a/apps/api/internal/domain/models.go
+++ b/apps/api/internal/domain/models.go
@@ -37,6 +37,7 @@ type ProviderConfigField struct {
 	Min      *float64                    `json:"min,omitempty"`
 	Max      *float64                    `json:"max,omitempty"`
 	Step     *float64                    `json:"step,omitempty"`
+	Group    string                      `json:"group,omitempty"`
 }
 
 type ProviderConfigFieldOption struct {

--- a/apps/api/internal/provider/palworld/config.go
+++ b/apps/api/internal/provider/palworld/config.go
@@ -4,7 +4,7 @@ import "github.com/smartcat999/game-panel-lite/apps/api/internal/domain"
 
 func configSchema() []domain.ProviderConfigField {
 	n := func(value float64) *float64 { return &value }
-	return []domain.ProviderConfigField{
+	fields := []domain.ProviderConfigField{
 		{Name: "serverName", Label: "服务器名称", Type: "text", Required: true, Default: "Palworld Server"},
 		{Name: "saveName", Label: "存档名称", Type: "text", Required: true, Default: "Palworld Save"},
 		{Name: "maxPlayers", Label: "最大玩家数", Type: "number", Required: true, Default: 8, Min: n(1), Max: n(32), Step: n(1)},
@@ -40,4 +40,15 @@ func configSchema() []domain.ProviderConfigField {
 		{Name: "enableFastTravel", Label: "开启快速传送", Type: "boolean", Default: true},
 		{Name: "pvp", Label: "开启 PVP", Type: "boolean", Default: false},
 	}
+	groups := map[string]string{
+		"serverName": "基础设置", "saveName": "基础设置", "maxPlayers": "基础设置", "serverPassword": "基础设置", "adminPassword": "基础设置", "deathPenalty": "基础设置",
+		"eggHatchingTime": "世界倍率", "expRate": "世界倍率", "captureRate": "世界倍率", "palSpawnRate": "世界倍率", "enemyDropRate": "世界倍率", "collectionDropRate": "世界倍率", "dayTimeSpeedRate": "世界倍率", "nightTimeSpeedRate": "世界倍率", "collectionRespawnRate": "世界倍率", "supplyDropSpan": "世界倍率",
+		"baseCampMaxNum": "据点与公会", "baseCampMaxNumInGuild": "据点与公会", "baseCampWorkerMaxNum": "据点与公会", "guildPlayerMaxNum": "据点与公会", "buildingDeteriorationRate": "据点与公会",
+		"playerDamageAttackRate": "生存与战斗", "playerDamageDefenseRate": "生存与战斗", "palDamageAttackRate": "生存与战斗", "palDamageDefenseRate": "生存与战斗", "playerStaminaRate": "生存与战斗", "playerHungerRate": "生存与战斗", "palStaminaRate": "生存与战斗", "palHungerRate": "生存与战斗", "itemCorruptionRate": "生存与战斗", "equipmentDurabilityRate": "生存与战斗",
+		"enableInvaderEnemy": "功能开关", "enableFastTravel": "功能开关", "pvp": "功能开关",
+	}
+	for index := range fields {
+		fields[index].Group = groups[fields[index].Name]
+	}
+	return fields
 }

--- a/apps/web/app/servers/[id]/page.tsx
+++ b/apps/web/app/servers/[id]/page.tsx
@@ -1844,9 +1844,18 @@ function ProviderConfigFields({
   if (fields.length === 0) {
     return <p className="mt-4 rounded-md border border-panel-line bg-slate-950/50 px-3 py-2 text-sm text-slate-500">{t("none")}</p>;
   }
+  const groupedFields = Array.from(fields.reduce((groups, field) => {
+    const group = field.group || "其他设置";
+    groups.set(group, [...(groups.get(group) ?? []), field]);
+    return groups;
+  }, new Map<string, ProviderConfigField[]>()));
   return (
-    <div className="mt-4 grid gap-4 lg:grid-cols-2">
-      {fields.map((field) => {
+    <div className="mt-4 grid gap-3">
+      {groupedFields.map(([group, groupFields], groupIndex) => (
+        <details key={group} open={groupIndex === 0} className="rounded-lg border border-panel-line bg-slate-950/35">
+          <summary className="cursor-pointer select-none px-4 py-3 text-sm font-semibold text-slate-200 hover:text-white">{group}<span className="ml-2 text-xs font-normal text-slate-500">{groupFields.length}</span></summary>
+          <div className="grid gap-4 border-t border-panel-line px-4 py-4 lg:grid-cols-2">
+      {groupFields.map((field) => {
         const label = providerFieldLabel(field, t);
         const help = providerFieldHelp(field, t);
         const value = providerConfigValue(payload, field.name);
@@ -1881,6 +1890,9 @@ function ProviderConfigFields({
           </Field>
         );
       })}
+          </div>
+        </details>
+      ))}
     </div>
   );
 }

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -26,6 +26,7 @@ export type ProviderConfigField = {
   min?: number;
   max?: number;
   step?: number;
+  group?: string;
 };
 
 export type RuntimeImageStatus = {


### PR DESCRIPTION
## Summary
- add generic provider field group metadata
- organize Palworld settings into five task-focused sections
- render collapsible groups on the server configuration page
- keep the basic group open and advanced groups collapsed by default

## Validation
- go test ./apps/api/internal/provider/palworld ./apps/api/internal/http
- pnpm --dir apps/web typecheck
- git diff --check