### PR TITLE
fix: sync Palworld online player count

### DIFF
--- a/apps/api/internal/player/syncer.go
+++ b/apps/api/internal/player/syncer.go
@@ -77,8 +77,9 @@ func (s *Syncer) RunOnce(ctx context.Context) error {
 		if !ok {
 			continue
 		}
-		playerProvider, ok := gameProvider.(provider.PlayerListProvider)
-		if !ok {
+		playerProvider, hasPlayerList := gameProvider.(provider.PlayerListProvider)
+		countProvider, hasPlayerCount := gameProvider.(provider.PlayerCountLogProvider)
+		if !hasPlayerList && !hasPlayerCount {
 			continue
 		}
 		lines, err := s.recentLogLines(ctx, server.Status.RuntimeID)
@@ -86,13 +87,18 @@ func (s *Syncer) RunOnce(ctx context.Context) error {
 			s.logger.Warn("failed to read player log output", "server", server.ID, "error", err)
 			continue
 		}
-		players := playerProvider.ParsePlayerListOutput(lines)
-		if players == nil {
+		var nextCount *int
+		if hasPlayerCount {
+			nextCount = countProvider.ParsePlayerCount(lines)
+		} else if players := playerProvider.ParsePlayerListOutput(lines); players != nil {
+			count := len(players)
+			nextCount = &count
+		}
+		if nextCount == nil {
 			continue
 		}
-		nextCount := len(players)
-		if nextCount != server.Status.PlayersOnline {
-			server.Status.PlayersOnline = nextCount
+		if *nextCount != server.Status.PlayersOnline {
+			server.Status.PlayersOnline = *nextCount
 			server.UpdatedAt = time.Now()
 			if err := s.store.SaveGameServer(ctx, &server); err != nil {
 				return err

--- a/apps/api/internal/player/syncer_test.go
+++ b/apps/api/internal/player/syncer_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/smartcat999/game-panel-lite/apps/api/internal/config"
 	"github.com/smartcat999/game-panel-lite/apps/api/internal/domain"
 	"github.com/smartcat999/game-panel-lite/apps/api/internal/provider"
+	"github.com/smartcat999/game-panel-lite/apps/api/internal/provider/palworld"
 	"github.com/smartcat999/game-panel-lite/apps/api/internal/provider/terraria"
 	"github.com/smartcat999/game-panel-lite/apps/api/internal/runtime"
 	"github.com/smartcat999/game-panel-lite/apps/api/internal/store"
@@ -140,5 +141,34 @@ func TestRunOnceClearsPlayerCountForStoppedServer(t *testing.T) {
 	}
 	if updated.Status.PlayersOnline != 0 {
 		t.Fatalf("expected stopped server player count to reset, got %+v", updated)
+	}
+}
+
+func TestRunOnceUpdatesPalworldCountFromPlayerLogging(t *testing.T) {
+	db, err := store.Open(t.TempDir() + "/gamepanel.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	server := domain.GameServer{
+		ID: "palworld-1", Name: "Pal Friends", GameKey: domain.GamePalworld, ProviderKey: domain.ProviderPalworld,
+		Spec:      domain.ServerSpec{Config: map[string]any{"maxPlayers": 8}},
+		Status:    domain.ServerRuntimeStatus{Phase: domain.PhaseRunning, ActualState: domain.ActualRunning, RuntimeID: "container-palworld"},
+		CreatedAt: now, UpdatedAt: now,
+	}
+	if err := db.CreateGameServer(context.Background(), &server); err != nil {
+		t.Fatal(err)
+	}
+	runtimeAdapter := &playerRuntime{logs: "Running Palworld dedicated server on :8211\nAlice has joined\nBob has joined\nAlice has left\n"}
+	syncer := NewSyncer(db, provider.NewRegistry(palworld.NewProvider()), runtimeAdapter, config.Config{})
+	if err := syncer.RunOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	updated, err := db.GetGameServer(context.Background(), server.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Status.PlayersOnline != 1 {
+		t.Fatalf("expected one Palworld player online, got %d", updated.Status.PlayersOnline)
 	}
 }

--- a/apps/api/internal/provider/palworld/provider.go
+++ b/apps/api/internal/provider/palworld/provider.go
@@ -3,6 +3,7 @@ package palworld
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/smartcat999/game-panel-lite/apps/api/internal/domain"
@@ -13,6 +14,8 @@ import (
 const DefaultInternalPort = 8211
 
 var versions = []string{"v2.5.0", "v2.4.2", "v2.4.1"}
+
+var ansiEscapePattern = regexp.MustCompile(`\x1b\[[0-9;]*[A-Za-z]`)
 
 type Provider struct {
 	runtime runtimecatalog.RuntimeConfig
@@ -232,6 +235,35 @@ func (p Provider) JoinInfo(server domain.GameServer) domain.ServerJoinInfo {
 			"Join by address using the host and port shown here.",
 		},
 	}
+}
+
+// ParsePlayerCount replays the image's REST-backed player logging from the
+// most recent server start. Only the helper's "has joined/left" messages are
+// consumed because Palworld also logs native events for the same player.
+func (Provider) ParsePlayerCount(lines []string) *int {
+	start := -1
+	for index, raw := range lines {
+		line := ansiEscapePattern.ReplaceAllString(raw, "")
+		if strings.Contains(line, "Running Palworld dedicated server") {
+			start = index
+		}
+	}
+	if start < 0 {
+		return nil
+	}
+	count := 0
+	for _, raw := range lines[start+1:] {
+		line := strings.TrimSpace(ansiEscapePattern.ReplaceAllString(raw, ""))
+		switch {
+		case strings.HasSuffix(line, " has joined"):
+			count++
+		case strings.HasSuffix(line, " has left"):
+			if count > 0 {
+				count--
+			}
+		}
+	}
+	return &count
 }
 
 func normalizeConfig(config Config) Config {

--- a/apps/api/internal/provider/palworld/provider_test.go
+++ b/apps/api/internal/provider/palworld/provider_test.go
@@ -132,3 +132,23 @@ func TestRenderConfigSummary(t *testing.T) {
 		}
 	}
 }
+
+func TestParsePlayerCount(t *testing.T) {
+	provider := NewProvider()
+	count := provider.ParsePlayerCount([]string{
+		"old player has joined",
+		"\x1b[0mRunning Palworld dedicated server on :8211",
+		"[LOG] Alice joined the server.",
+		"\x1b[0;37mAlice has joined\x1b[0m",
+		"Bob has joined",
+		"[LOG] Alice left the server.",
+		"Alice has left",
+	})
+	if count == nil || *count != 1 {
+		t.Fatalf("expected one online player, got %v", count)
+	}
+
+	if count := provider.ParsePlayerCount([]string{"Alice has joined"}); count != nil {
+		t.Fatalf("expected incomplete snapshot to preserve prior count, got %d", *count)
+	}
+}

--- a/apps/api/internal/provider/provider.go
+++ b/apps/api/internal/provider/provider.go
@@ -60,6 +60,12 @@ type PlayerActivityProvider interface {
 	ParsePlayerLogEvent(string) (domain.PlayerLogEvent, bool)
 }
 
+// PlayerCountLogProvider derives the current online count from a bounded
+// workload log snapshot. A nil result means the snapshot is incomplete.
+type PlayerCountLogProvider interface {
+	ParsePlayerCount([]string) *int
+}
+
 type Registry struct {
 	providers map[domain.ProviderKey]GameProvider
 }


### PR DESCRIPTION
## Summary
- derive Palworld online count from the runtime image REST-backed player activity log
- replay events from the latest server start every 30 seconds
- avoid double-counting native Palworld join/leave messages
- preserve the prior count when the bounded log snapshot does not include a server start

## Verification
- go test ./...
- go vet ./...