### PR TITLE
fix: avoid Palworld 5 GB verification on every restart

### DIFF
--- a/apps/api/internal/provider/palworld/provider.go
+++ b/apps/api/internal/provider/palworld/provider.go
@@ -178,7 +178,10 @@ func runtimeOptions(config Config) runtime.ContainerOptions {
 			"ADMIN_PASSWORD=" + config.AdminPassword,
 			"MULTITHREADING=true",
 			"COMMUNITY=false",
-			"UPDATE_ON_BOOT=true",
+			// GamePanel manages runtime image upgrades explicitly. Re-running
+			// SteamCMD on every container restart needlessly verifies ~5 GB and
+			// can replace PalServer.sh while the instance is recovering.
+			"UPDATE_ON_BOOT=false",
 			fmt.Sprintf("PAL_EGG_DEFAULT_HATCHING_TIME=%g", config.EggHatchingTime),
 			fmt.Sprintf("EXP_RATE=%g", config.ExpRate), fmt.Sprintf("PAL_CAPTURE_RATE=%g", config.CaptureRate),
 			fmt.Sprintf("PAL_SPAWN_NUM_RATE=%g", config.PalSpawnRate), fmt.Sprintf("ENEMY_DROP_ITEM_RATE=%g", config.EnemyDropRate),

--- a/apps/api/internal/provider/palworld/provider_test.go
+++ b/apps/api/internal/provider/palworld/provider_test.go
@@ -102,6 +102,7 @@ func TestServerRuntimeUsesSemanticConfigPayload(t *testing.T) {
 		"SERVER_NAME=Payload Name",
 		"SERVER_PASSWORD=payload-password",
 		"ADMIN_PASSWORD=payload-admin",
+		"UPDATE_ON_BOOT=false",
 	} {
 		if !strings.Contains(env, expected) {
 			t.Fatalf("expected payload env to contain %q, got:\n%s", expected, env)

--- a/docker/palworld/README.md
+++ b/docker/palworld/README.md
@@ -1,6 +1,6 @@
 # Palworld Server Image
 
-This image packages the stable `thijsvanloef/palworld-server-docker` runtime under the GamePanel Lite image namespace. The runtime installs or updates Palworld Dedicated Server (Steam app `2394010`) when the container starts because the provider sets `UPDATE_ON_BOOT=true`.
+This image packages the stable `thijsvanloef/palworld-server-docker` runtime under the GamePanel Lite image namespace. GamePanel sets `UPDATE_ON_BOOT=false` after the initial installation so ordinary container restarts reuse the installed Palworld Dedicated Server files instead of verifying roughly 5 GB through SteamCMD every time. Runtime image upgrades are managed explicitly by GamePanel.
 
 Build and load the current version for the local Docker architecture:
 


### PR DESCRIPTION
## Summary
- set UPDATE_ON_BOOT=false for Palworld workloads
- reuse the existing dedicated-server installation on ordinary restarts
- document the explicit runtime image upgrade behavior

## Verification
- go test ./apps/api/internal/provider/palworld ./apps/api/internal/server ./apps/api/internal/http
- go vet ./apps/api/internal/provider/palworld/...