### PR TITLE
fix: restore panel and running game servers after reboot

### DIFF
--- a/apps/api/internal/runtime/docker/adapter.go
+++ b/apps/api/internal/runtime/docker/adapter.go
@@ -80,6 +80,10 @@ func (a *Adapter) createContainer(ctx context.Context, spec runtime.ContainerSpe
 	hostConfig := &container.HostConfig{
 		Binds:        binds,
 		PortBindings: natPortMap(spec.Port, spec.HostPort, spec.Options.PortProtocol),
+		// Docker remembers containers stopped explicitly by the user. With
+		// unless-stopped, desired-running game servers recover after a host or
+		// daemon restart while instances stopped through GamePanel stay stopped.
+		RestartPolicy: container.RestartPolicy{Name: "unless-stopped"},
 	}
 	if spec.Resources.CPULimitCores > 0 {
 		hostConfig.Resources.NanoCPUs = int64(spec.Resources.CPULimitCores * 1_000_000_000)

--- a/compose.https.yaml
+++ b/compose.https.yaml
@@ -8,6 +8,7 @@ services:
   nginx-https:
     image: nginx:1.27-alpine
     pull_policy: missing
+    restart: unless-stopped
     depends_on:
       - api
       - web

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -2,6 +2,7 @@ services:
   api:
     image: ${GAMEPANEL_IMAGE_REGISTRY:-smartcat99999}/game-panel-lite-api:${GAMEPANEL_IMAGE_TAG:-v0.1.0}
     pull_policy: always
+    restart: unless-stopped
     environment:
       GAMEPANEL_HOST: 0.0.0.0
       GAMEPANEL_PORT: 4000
@@ -25,6 +26,7 @@ services:
   gamepanel-exporter:
     image: ${GAMEPANEL_IMAGE_REGISTRY:-smartcat99999}/game-panel-lite-exporter:${GAMEPANEL_IMAGE_TAG:-v0.1.0}
     pull_policy: always
+    restart: unless-stopped
     environment:
       GAMEPANEL_HOST: 0.0.0.0
       GAMEPANEL_PORT: 4010
@@ -51,6 +53,7 @@ services:
   prometheus:
     image: ${GAMEPANEL_IMAGE_REGISTRY:-smartcat99999}/prometheus:v2.55.1
     pull_policy: missing
+    restart: unless-stopped
     command:
       - --config.file=/etc/prometheus/prometheus.yml
       - --storage.tsdb.path=/prometheus
@@ -70,6 +73,7 @@ services:
   cadvisor:
     image: ${GAMEPANEL_IMAGE_REGISTRY:-smartcat99999}/cadvisor:v0.52.1
     pull_policy: missing
+    restart: unless-stopped
     privileged: true
     ports:
       - "8081:8080"
@@ -83,6 +87,7 @@ services:
   node-exporter:
     image: ${GAMEPANEL_IMAGE_REGISTRY:-smartcat99999}/node-exporter:v1.10.2
     pull_policy: missing
+    restart: unless-stopped
     command:
       - --path.rootfs=/host
     network_mode: host
@@ -93,6 +98,7 @@ services:
   web:
     image: ${GAMEPANEL_IMAGE_REGISTRY:-smartcat99999}/game-panel-lite-web:${GAMEPANEL_IMAGE_TAG:-v0.1.0}
     pull_policy: always
+    restart: unless-stopped
     environment:
       NEXT_PUBLIC_API_BASE_URL: ${NEXT_PUBLIC_API_BASE_URL:-}
     depends_on:


### PR DESCRIPTION
## Summary
- create game workloads with Docker unless-stopped restart policy
- restart panel API, Web, monitoring, and HTTPS proxy after host reboot
- preserve explicit user stops because Docker does not restart manually stopped unless-stopped containers
- leave the plain HTTP proxy unmanaged to avoid an 80-port conflict with HTTPS

## Verification
- go test ./apps/api/internal/runtime/docker ./apps/api/internal/server
- go vet ./apps/api/internal/runtime/docker/...
- docker compose config for production and HTTPS overlays