### PR TITLE
fix: build DST runtime without Steam credentials

### DIFF
--- a/docker/dst/Dockerfile
+++ b/docker/dst/Dockerfile
@@ -1,51 +1,17 @@
 # syntax=docker/dockerfile:1.7
 
-FROM debian:bookworm-slim AS installer
-
-ARG STEAMCMD_URL=https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz
-ARG DST_APP_ID=343050
-
-RUN dpkg --add-architecture i386 \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates curl tar lib32gcc-s1 \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN --mount=type=secret,id=steam_username,required=false \
-    --mount=type=secret,id=steam_password,required=false \
-    mkdir -p /opt/steamcmd /opt/dst \
-    && curl -fsSL "${STEAMCMD_URL}" -o /tmp/steamcmd_linux.tar.gz \
-    && tar -xzf /tmp/steamcmd_linux.tar.gz -C /opt/steamcmd \
-    && if [ -s /run/secrets/steam_username ] && [ -s /run/secrets/steam_password ]; then \
-        steam_user="$(cat /run/secrets/steam_username)"; \
-        steam_password="$(cat /run/secrets/steam_password)"; \
-        /opt/steamcmd/steamcmd.sh \
-          +@ShutdownOnFailedCommand 1 \
-          +@NoPromptForPassword 1 \
-          +@sSteamCmdForcePlatformType linux \
-          +force_install_dir /opt/dst \
-          +login "${steam_user}" "${steam_password}" \
-          +app_update "${DST_APP_ID}" validate \
-          +quit; \
-      else \
-        /opt/steamcmd/steamcmd.sh \
-        +@ShutdownOnFailedCommand 1 \
-        +@NoPromptForPassword 1 \
-        +@sSteamCmdForcePlatformType linux \
-        +force_install_dir /opt/dst \
-        +login anonymous \
-        +app_update "${DST_APP_ID}" validate \
-        +quit || { \
-          echo "DST Steam app ${DST_APP_ID} could not be installed anonymously." >&2; \
-          echo "Set STEAM_USERNAME and STEAM_PASSWORD when building this image so BuildKit can pass them as temporary secrets." >&2; \
-          exit 1; \
-        }; \
-      fi \
-    && rm -f /tmp/steamcmd_linux.tar.gz
+# SteamCMD occasionally returns "Missing configuration" for the public DST app
+# even though app 343050 supports anonymous installation. Use a digest-pinned,
+# preinstalled upstream image as the binary source so builds stay reproducible
+# and never require a personal Steam account.
+ARG DST_BASE_IMAGE=webhippie/dst@sha256:f4479666ebb55903f2f1e5a94f4c4dcd5fae5d6a7eb896cb6285d1860d789bad
+FROM ${DST_BASE_IMAGE} AS installer
 
 FROM debian:bookworm-slim
 
 LABEL org.opencontainers.image.title="GamePanel Lite Don't Starve Together"
 LABEL org.opencontainers.image.description="Prebuilt Don't Starve Together dedicated server runtime for GamePanel Lite"
+LABEL org.opencontainers.image.base.name="docker.io/webhippie/dst@sha256:f4479666ebb55903f2f1e5a94f4c4dcd5fae5d6a7eb896cb6285d1860d789bad"
 
 RUN dpkg --add-architecture i386 \
     && apt-get update \
@@ -57,7 +23,7 @@ RUN dpkg --add-architecture i386 \
 
 USER container
 WORKDIR /home/container
-COPY --from=installer --chown=container:container /opt/dst/ /home/container/server/
+COPY --from=installer --chown=container:container /usr/share/game/ /home/container/server/
 COPY --chmod=755 --chown=container:container docker/dst/gamepanel-dst-entrypoint.sh /home/container/gamepanel-dst-entrypoint.sh
 
 ENV DST_PERSISTENT_ROOT=/data

--- a/docker/dst/README.md
+++ b/docker/dst/README.md
@@ -12,17 +12,7 @@ scripts/build-game-images.sh dst --platform linux/amd64 --load
 
 By default this loads the runtime image as `smartcat99999/dst-server:latest`, matching the image namespace used by the other GamePanel Lite runtime images.
 
-The Dockerfile downloads Steam app `343050` and forces the SteamCMD platform to `linux` so the Linux dedicated-server depot is selected.
-
-Steam currently reports this app as owner-only for anonymous SteamCMD installs. If anonymous installation fails with `Missing configuration`, build with a Steam account that can access the free DST Dedicated Server tool. The build script passes credentials as BuildKit secrets when these environment variables are present; they are not stored in the final image:
-
-```bash
-STEAM_USERNAME='your-steam-user' \
-STEAM_PASSWORD='your-steam-password' \
-scripts/build-game-images.sh dst --platform linux/amd64 --push
-```
-
-If Steam Guard blocks the login, sign in with SteamCMD once on the amd64 builder host to approve the account, then rerun the build.
+Steam app `343050` supports anonymous SteamCMD installation, but Steam can temporarily return `Missing configuration` during image builds. To keep builds reproducible and avoid personal Steam credentials, the Dockerfile copies the preinstalled server files from a digest-pinned `webhippie/dst` image, then runs them with GamePanel Lite's own unprivileged runtime and entrypoint.
 
 Docker buildx is supported. The build script passes `--platform` and `--builder` through to buildx, the same as the other runtime images. On Apple Silicon or other arm hosts, make sure the active buildx builder has an amd64 node. If the builder falls back to local QEMU emulation, SteamCMD can exit with a segmentation fault before the DST server files are downloaded.
 

--- a/scripts/build-game-images.sh
+++ b/scripts/build-game-images.sh
@@ -147,17 +147,6 @@ build_dst() {
     echo "Don't Starve Together image builds are currently supported only for linux/amd64." >&2
     exit 1
   fi
-  if [[ -n "${STEAM_USERNAME:-}" && -z "${STEAM_PASSWORD:-}" || -z "${STEAM_USERNAME:-}" && -n "${STEAM_PASSWORD:-}" ]]; then
-    echo "Set both STEAM_USERNAME and STEAM_PASSWORD when building the Don't Starve Together image with Steam credentials." >&2
-    exit 1
-  fi
-  if [[ -n "${STEAM_USERNAME:-}" ]]; then
-    dst_buildx_args+=(--secret id=steam_username,env=STEAM_USERNAME)
-  fi
-  if [[ -n "${STEAM_PASSWORD:-}" ]]; then
-    dst_buildx_args+=(--secret id=steam_password,env=STEAM_PASSWORD)
-  fi
-
   echo "==> Building ${image}"
   docker "${dst_buildx_args[@]}" \
     -f docker/dst/Dockerfile \


### PR DESCRIPTION
## Summary
- source preinstalled DST server files from a digest-pinned, current webhippie/dst amd64 image
- keep the GamePanel Lite unprivileged runtime and entrypoint
- remove personal Steam credential handling from the build script
- document anonymous SteamCMD behavior and the reproducible fallback

## Verification
- bash -n scripts/build-game-images.sh docker/dst/gamepanel-dst-entrypoint.sh
- git diff --check
- built and pushed linux/amd64 image to registry.cn-hangzhou.aliyuncs.com/gamepanel-lite/dst-server:v2026.06.21
