### PR TITLE
fix: render current DST world and shard config

### DIFF
--- a/apps/api/internal/provider/dst/provider.go
+++ b/apps/api/internal/provider/dst/provider.go
@@ -424,6 +424,17 @@ func renderClusterINI(config Config) string {
 		"console_enabled = " + boolINI(config.Gameplay.ConsoleEnabled),
 		"",
 	}
+	if config.Caves != nil && config.Caves.Enabled {
+		lines = append(lines,
+			"[SHARD]",
+			"shard_enabled = true",
+			"bind_ip = 127.0.0.1",
+			"master_ip = 127.0.0.1",
+			"master_port = 10888",
+			"cluster_key = gamepanel-lite",
+			"",
+		)
+	}
 	return strings.Join(lines, "\n")
 }
 
@@ -460,9 +471,15 @@ func renderLevelDataOverrideLua(location string, preset string, overrides map[st
 			preset = "forest_default"
 		}
 	}
+	name := "Forest"
+	if location == "cave" {
+		name = "Caves"
+	}
 	lines := []string{
 		"return {",
 		"  id = \"SURVIVAL_TOGETHER\",",
+		fmt.Sprintf("  name = %q,", name),
+		"  desc = \"\",",
 		fmt.Sprintf("  location = %q,", location),
 		"  version = 4,",
 		"  override_enabled = true,",

--- a/apps/api/internal/provider/dst/provider_test.go
+++ b/apps/api/internal/provider/dst/provider_test.go
@@ -135,6 +135,16 @@ func TestServerRuntimeUsesSemanticConfigPayload(t *testing.T) {
 	if !strings.Contains(options.Files["dst/Payload Cluster/Master/leveldataoverride.lua"], `preset = "forest_classic"`) {
 		t.Fatalf("expected payload world preset in Master leveldataoverride, got:\n%s", options.Files["dst/Payload Cluster/Master/leveldataoverride.lua"])
 	}
+	for _, expected := range []string{`name = "Forest"`, `desc = ""`} {
+		if !strings.Contains(options.Files["dst/Payload Cluster/Master/leveldataoverride.lua"], expected) {
+			t.Fatalf("expected current DST level data field %q, got:\n%s", expected, options.Files["dst/Payload Cluster/Master/leveldataoverride.lua"])
+		}
+	}
+	for _, expected := range []string{"[SHARD]", "shard_enabled = true", "master_port = 10888", "cluster_key = gamepanel-lite"} {
+		if !strings.Contains(options.Files["dst/Payload Cluster/cluster.ini"], expected) {
+			t.Fatalf("expected caves shard setting %q, got:\n%s", expected, options.Files["dst/Payload Cluster/cluster.ini"])
+		}
+	}
 	if _, ok := options.Files["dst/Payload Cluster/Caves/server.ini"]; !ok {
 		t.Fatalf("expected caves shard files when caves are enabled, got %+v", options.Files)
 	}


### PR DESCRIPTION
## Summary
- add the `name` and `desc` fields required by current DST `leveldataoverride.lua` validation
- enable and configure local Master/Caves shard communication when caves are enabled
- cover current level-data and shard fields in provider tests

## Verification
- go test ./apps/api/internal/provider/dst
- go test ./apps/api/internal/http
- production hotfix verified Master 10999 and Caves 11000 start without `Level data override is invalid`
- production UDP 7779 listening
