### PR TITLE
fix: add DST world generation task sets

### DIFF
--- a/apps/api/internal/provider/dst/provider.go
+++ b/apps/api/internal/provider/dst/provider.go
@@ -472,8 +472,10 @@ func renderLevelDataOverrideLua(location string, preset string, overrides map[st
 		}
 	}
 	name := "Forest"
+	taskSet := "default"
 	if location == "cave" {
 		name = "Caves"
+		taskSet = "cave_default"
 	}
 	lines := []string{
 		"return {",
@@ -481,6 +483,7 @@ func renderLevelDataOverrideLua(location string, preset string, overrides map[st
 		fmt.Sprintf("  name = %q,", name),
 		"  desc = \"\",",
 		fmt.Sprintf("  location = %q,", location),
+		fmt.Sprintf("  task_set = %q,", taskSet),
 		"  version = 4,",
 		"  override_enabled = true,",
 		fmt.Sprintf("  preset = %q,", preset),

--- a/apps/api/internal/provider/dst/provider_test.go
+++ b/apps/api/internal/provider/dst/provider_test.go
@@ -135,7 +135,7 @@ func TestServerRuntimeUsesSemanticConfigPayload(t *testing.T) {
 	if !strings.Contains(options.Files["dst/Payload Cluster/Master/leveldataoverride.lua"], `preset = "forest_classic"`) {
 		t.Fatalf("expected payload world preset in Master leveldataoverride, got:\n%s", options.Files["dst/Payload Cluster/Master/leveldataoverride.lua"])
 	}
-	for _, expected := range []string{`name = "Forest"`, `desc = ""`} {
+	for _, expected := range []string{`name = "Forest"`, `desc = ""`, `task_set = "default"`} {
 		if !strings.Contains(options.Files["dst/Payload Cluster/Master/leveldataoverride.lua"], expected) {
 			t.Fatalf("expected current DST level data field %q, got:\n%s", expected, options.Files["dst/Payload Cluster/Master/leveldataoverride.lua"])
 		}
@@ -147,6 +147,9 @@ func TestServerRuntimeUsesSemanticConfigPayload(t *testing.T) {
 	}
 	if _, ok := options.Files["dst/Payload Cluster/Caves/server.ini"]; !ok {
 		t.Fatalf("expected caves shard files when caves are enabled, got %+v", options.Files)
+	}
+	if !strings.Contains(options.Files["dst/Payload Cluster/Caves/leveldataoverride.lua"], `task_set = "cave_default"`) {
+		t.Fatalf("expected cave task set in Caves leveldataoverride, got:\n%s", options.Files["dst/Payload Cluster/Caves/leveldataoverride.lua"])
 	}
 	if !strings.Contains(options.Files["dst/Payload Cluster/dedicated_server_mods_setup.lua"], `ServerModSetup("123456789")`) {
 		t.Fatalf("expected workshop setup file, got:\n%s", options.Files["dst/Payload Cluster/dedicated_server_mods_setup.lua"])


### PR DESCRIPTION
## Summary
- render the required default task set for DST forest worlds
- render the cave default task set for cave shards
- add regression coverage for both generated files

## Verification
- go test ./...
- go vet ./...
- pnpm --dir apps/web lint
- pnpm --dir apps/web typecheck
- pnpm --dir apps/web build