### PR TITLE
fix: nest DST task sets in world overrides

### DIFF
--- a/apps/api/internal/provider/dst/provider.go
+++ b/apps/api/internal/provider/dst/provider.go
@@ -483,13 +483,16 @@ func renderLevelDataOverrideLua(location string, preset string, overrides map[st
 		fmt.Sprintf("  name = %q,", name),
 		"  desc = \"\",",
 		fmt.Sprintf("  location = %q,", location),
-		fmt.Sprintf("  task_set = %q,", taskSet),
 		"  version = 4,",
 		"  override_enabled = true,",
 		fmt.Sprintf("  preset = %q,", preset),
 		"  overrides = {",
+		fmt.Sprintf("    task_set = %q,", taskSet),
 	}
 	for _, key := range sortedStringKeys(overrides) {
+		if key == "task_set" {
+			continue
+		}
 		lines = append(lines, fmt.Sprintf("    %s = %q,", key, overrides[key]))
 	}
 	lines = append(lines, "  },", "}", "")

--- a/apps/api/internal/provider/dst/provider_test.go
+++ b/apps/api/internal/provider/dst/provider_test.go
@@ -135,7 +135,7 @@ func TestServerRuntimeUsesSemanticConfigPayload(t *testing.T) {
 	if !strings.Contains(options.Files["dst/Payload Cluster/Master/leveldataoverride.lua"], `preset = "forest_classic"`) {
 		t.Fatalf("expected payload world preset in Master leveldataoverride, got:\n%s", options.Files["dst/Payload Cluster/Master/leveldataoverride.lua"])
 	}
-	for _, expected := range []string{`name = "Forest"`, `desc = ""`, `task_set = "default"`} {
+	for _, expected := range []string{`name = "Forest"`, `desc = ""`, "overrides = {\n    task_set = \"default\","} {
 		if !strings.Contains(options.Files["dst/Payload Cluster/Master/leveldataoverride.lua"], expected) {
 			t.Fatalf("expected current DST level data field %q, got:\n%s", expected, options.Files["dst/Payload Cluster/Master/leveldataoverride.lua"])
 		}
@@ -148,7 +148,7 @@ func TestServerRuntimeUsesSemanticConfigPayload(t *testing.T) {
 	if _, ok := options.Files["dst/Payload Cluster/Caves/server.ini"]; !ok {
 		t.Fatalf("expected caves shard files when caves are enabled, got %+v", options.Files)
 	}
-	if !strings.Contains(options.Files["dst/Payload Cluster/Caves/leveldataoverride.lua"], `task_set = "cave_default"`) {
+	if !strings.Contains(options.Files["dst/Payload Cluster/Caves/leveldataoverride.lua"], "overrides = {\n    task_set = \"cave_default\",") {
 		t.Fatalf("expected cave task set in Caves leveldataoverride, got:\n%s", options.Files["dst/Payload Cluster/Caves/leveldataoverride.lua"])
 	}
 	if !strings.Contains(options.Files["dst/Payload Cluster/dedicated_server_mods_setup.lua"], `ServerModSetup("123456789")`) {


### PR DESCRIPTION
## Root cause
DST 739495 reads the task set from Level.overrides["task_set"]. The previous top-level field was loaded from Lua but discarded by the Level constructor.

## Fix
- render forest and cave task sets inside the overrides table
- prevent a duplicate user-provided task_set key
- assert the nested structure in regression tests

## Verification
- go test ./...
- go vet ./...