### PR TITLE
fix: render complete DST level presets

### DIFF
--- a/apps/api/internal/provider/dst/provider.go
+++ b/apps/api/internal/provider/dst/provider.go
@@ -472,14 +472,36 @@ func renderLevelDataOverrideLua(location string, preset string, overrides map[st
 		}
 	}
 	name := "Forest"
-	taskSet := "default"
+	levelID := "SURVIVAL_TOGETHER"
+	defaultOverrides := map[string]string{
+		"has_ocean":                          "true",
+		"keep_disconnected_tiles":            "true",
+		"layout_mode":                        `"LinkNodesByKeys"`,
+		"no_joining_islands":                 "true",
+		"no_wormholes_to_disconnected_tiles": "true",
+		"roads":                              `"default"`,
+		"season_start":                       `"default"`,
+		"start_location":                     `"default"`,
+		"task_set":                           `"default"`,
+		"world_size":                         `"default"`,
+		"wormhole_prefab":                    `"wormhole"`,
+	}
 	if location == "cave" {
 		name = "Caves"
-		taskSet = "cave_default"
+		levelID = "DST_CAVE"
+		defaultOverrides = map[string]string{
+			"layout_mode":     `"RestrictNodesByKey"`,
+			"roads":           `"never"`,
+			"season_start":    `"default"`,
+			"start_location":  `"caves"`,
+			"task_set":        `"cave_default"`,
+			"world_size":      `"default"`,
+			"wormhole_prefab": `"tentacle_pillar"`,
+		}
 	}
 	lines := []string{
 		"return {",
-		"  id = \"SURVIVAL_TOGETHER\",",
+		fmt.Sprintf("  id = %q,", levelID),
 		fmt.Sprintf("  name = %q,", name),
 		"  desc = \"\",",
 		fmt.Sprintf("  location = %q,", location),
@@ -487,15 +509,32 @@ func renderLevelDataOverrideLua(location string, preset string, overrides map[st
 		"  override_enabled = true,",
 		fmt.Sprintf("  preset = %q,", preset),
 		"  overrides = {",
-		fmt.Sprintf("    task_set = %q,", taskSet),
 	}
-	for _, key := range sortedStringKeys(overrides) {
-		if key == "task_set" {
+	for _, key := range sortedStringKeys(defaultOverrides) {
+		if _, overridden := overrides[key]; overridden {
 			continue
 		}
+		lines = append(lines, fmt.Sprintf("    %s = %s,", key, defaultOverrides[key]))
+	}
+	for _, key := range sortedStringKeys(overrides) {
 		lines = append(lines, fmt.Sprintf("    %s = %q,", key, overrides[key]))
 	}
-	lines = append(lines, "  },", "}", "")
+	lines = append(lines, "  },")
+	if location == "cave" {
+		lines = append(lines, "  background_node_range = { 0, 1 },")
+	} else {
+		lines = append(lines,
+			"  required_setpieces = { \"Sculptures_1\", \"Maxwell5\" },",
+			"  numrandom_set_pieces = 4,",
+			"  random_set_pieces = {",
+			"    \"Sculptures_2\", \"Sculptures_3\", \"Sculptures_4\", \"Sculptures_5\",",
+			"    \"Chessy_1\", \"Chessy_2\", \"Chessy_3\", \"Chessy_4\", \"Chessy_5\", \"Chessy_6\",",
+			"    \"Maxwell1\", \"Maxwell2\", \"Maxwell3\", \"Maxwell4\", \"Maxwell6\", \"Maxwell7\",",
+			"    \"Warzone_1\", \"Warzone_2\", \"Warzone_3\",",
+			"  },",
+		)
+	}
+	lines = append(lines, "}", "")
 	return strings.Join(lines, "\n")
 }
 

--- a/apps/api/internal/provider/dst/provider_test.go
+++ b/apps/api/internal/provider/dst/provider_test.go
@@ -135,7 +135,7 @@ func TestServerRuntimeUsesSemanticConfigPayload(t *testing.T) {
 	if !strings.Contains(options.Files["dst/Payload Cluster/Master/leveldataoverride.lua"], `preset = "forest_classic"`) {
 		t.Fatalf("expected payload world preset in Master leveldataoverride, got:\n%s", options.Files["dst/Payload Cluster/Master/leveldataoverride.lua"])
 	}
-	for _, expected := range []string{`name = "Forest"`, `desc = ""`, "overrides = {\n    task_set = \"default\","} {
+	for _, expected := range []string{`id = "SURVIVAL_TOGETHER"`, `name = "Forest"`, `desc = ""`, `layout_mode = "LinkNodesByKeys"`, `task_set = "default"`, `has_ocean = true`, `required_setpieces = { "Sculptures_1", "Maxwell5" }`, `numrandom_set_pieces = 4`} {
 		if !strings.Contains(options.Files["dst/Payload Cluster/Master/leveldataoverride.lua"], expected) {
 			t.Fatalf("expected current DST level data field %q, got:\n%s", expected, options.Files["dst/Payload Cluster/Master/leveldataoverride.lua"])
 		}
@@ -148,8 +148,10 @@ func TestServerRuntimeUsesSemanticConfigPayload(t *testing.T) {
 	if _, ok := options.Files["dst/Payload Cluster/Caves/server.ini"]; !ok {
 		t.Fatalf("expected caves shard files when caves are enabled, got %+v", options.Files)
 	}
-	if !strings.Contains(options.Files["dst/Payload Cluster/Caves/leveldataoverride.lua"], "overrides = {\n    task_set = \"cave_default\",") {
-		t.Fatalf("expected cave task set in Caves leveldataoverride, got:\n%s", options.Files["dst/Payload Cluster/Caves/leveldataoverride.lua"])
+	for _, expected := range []string{`id = "DST_CAVE"`, `layout_mode = "RestrictNodesByKey"`, `start_location = "caves"`, `task_set = "cave_default"`, `background_node_range = { 0, 1 }`} {
+		if !strings.Contains(options.Files["dst/Payload Cluster/Caves/leveldataoverride.lua"], expected) {
+			t.Fatalf("expected cave world generation default %q, got:\n%s", expected, options.Files["dst/Payload Cluster/Caves/leveldataoverride.lua"])
+		}
 	}
 	if !strings.Contains(options.Files["dst/Payload Cluster/dedicated_server_mods_setup.lua"], `ServerModSetup("123456789")`) {
 		t.Fatalf("expected workshop setup file, got:\n%s", options.Files["dst/Payload Cluster/dedicated_server_mods_setup.lua"])


### PR DESCRIPTION
## Root cause
The legacy generated leveldataoverride omitted current build 739495 location defaults and official Level fields. That caused sequential worldgen failures for task_set, layout_mode, and required sculpture set pieces; caves also used the wrong Level ID.

## Fix
- render official forest and cave location defaults inside overrides
- render SURVIVAL_TOGETHER required/random set pieces
- use DST_CAVE and its background node range for caves
- preserve user overrides
- cover current-build fields in tests

## Verification
- go test ./...
- go vet ./...
- production build 739495 generated both worlds
- Caves shard connected to Master