### PR TITLE
fix: show public host in server creation review

### DIFF
--- a/apps/web/components/create-server-wizard.tsx
+++ b/apps/web/components/create-server-wizard.tsx
@@ -16,7 +16,7 @@ import { gameDescription, gameDisplayName } from "@/lib/game-display";
 import { providerDescription, providerDisplayName } from "@/lib/provider-display";
 import { formatCreateServerError } from "@/lib/runtime-errors";
 import { cn } from "@/lib/utils";
-import { createConfigPreset, getGameVersions, listConfigPresets, listGames, listGlobalMods, listModPacks, listWorlds } from "@/lib/api";
+import { createConfigPreset, getGameVersions, getSettings, listConfigPresets, listGames, listGlobalMods, listModPacks, listWorlds } from "@/lib/api";
 import { defaultCreateServerConfig, defaultCreateServerMode, defaultCreateServerPreset } from "@/lib/create-server-defaults";
 import { createGameServerWithResources } from "@/lib/create-server-flow";
 import { createReviewInvitePreview, reviewJoinInstructionKey } from "@/lib/create-server-review";
@@ -380,6 +380,7 @@ export function CreateServerWizard() {
   const modsQuery = useQuery({ queryKey: ["global-mods"], queryFn: listGlobalMods, retry: false });
   const modPacksQuery = useQuery({ queryKey: ["mod-packs"], queryFn: listModPacks, retry: false });
   const configPresetsQuery = useQuery({ queryKey: ["config-presets"], queryFn: listConfigPresets, retry: false });
+  const settingsQuery = useQuery({ queryKey: ["settings"], queryFn: getSettings, staleTime: 5 * 60 * 1000, retry: false });
   const games = gamesQuery.data ?? [];
   const selectedGame = games.find((game) => game.key === selectedGameKey) ?? games[0] ?? games.find((game) => game.key === "terraria");
   const selectedGameArt = getGameArt(selectedGame?.coverImage ?? selectedGame?.key ?? selectedGameKey);
@@ -765,6 +766,7 @@ export function CreateServerWizard() {
             )}
             {currentStepId === "review" && (
               <ReviewStep
+                address={settingsQuery.data?.publicHost.trim() || undefined}
                 configModel={createReviewConfigModel({
                   config,
                   gameKey: selectedGameKey,
@@ -2111,6 +2113,7 @@ function ModsStep({
 }
 
 function ReviewStep({
+  address,
   configModel,
   gameKey,
   gameName,
@@ -2128,6 +2131,7 @@ function ReviewStep({
   onOpenPreset,
   onSavePreset
 }: {
+  address?: string;
   configModel: ReviewConfigModel;
   gameKey: string;
   gameName: string;
@@ -2147,6 +2151,7 @@ function ReviewStep({
 }) {
   const { t } = useI18n();
   const invitePreview = createReviewInvitePreview({
+    address,
     gameKey,
     gameName,
     hostPortLabel,

--- a/apps/web/lib/create-server-review.test.ts
+++ b/apps/web/lib/create-server-review.test.ts
@@ -14,6 +14,12 @@ describe("createReviewInvitePreview", () => {
     );
   });
 
+  it("uses the configured public address", () => {
+    expect(createReviewInvitePreview({ address: "43.161.250.66", gameKey: "palworld", hostPortLabel: "7778", serverName: "Pal Friends" })).toBe(
+      "Join Pal Friends in Palworld at 43.161.250.66:7778"
+    );
+  });
+
   it("creates Don't Starve Together invite preview text", () => {
     expect(createReviewInvitePreview({ gameKey: "dont-starve-together", hostPortLabel: "11099", password: "secret", serverName: "DST Friends" })).toBe(
       "Join DST Friends in Don't Starve Together at 127.0.0.1:11099 password: secret"


### PR DESCRIPTION
## Summary
- load the global public host in the create-server wizard
- use it in the final Join Server preview
- retain 127.0.0.1 only as the empty/error fallback
- add regression coverage for a configured public IP

## Verification
- pnpm --dir apps/web test -- --run
- pnpm --dir apps/web lint
- pnpm --dir apps/web typecheck
- pnpm --dir apps/web build