### PR TITLE
fix: unify production Nginx and remote operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ If you have a domain pointed at the server, enable HTTPS:
 cd ~/gamepanel-lite && sudo sh scripts/setup-https.sh your-domain.com your-email@example.com
 ```
 
+## Remote Server Operations
+
+Update the control-plane images and recreate only changed services:
+
+```bash
+cd ~/gamepanel-lite
+sudo sh scripts/manage.sh update
+```
+
+Use `start`, `stop`, or `status` in place of `update` for routine operations. The script automatically selects HTTP or HTTPS mode. It manages the panel control plane only; game containers remain under GamePanel Lite and are not recreated by these commands.
+
+Production uses `compose.prod.yaml`. The HTTPS override replaces the same `nginx` service, so only one reverse proxy owns ports 80 and 443. Do not add the development `compose.yaml` to production commands.
+
 ## Data Location
 
 GamePanel Lite stores its data in the `data/` directory inside the install folder. This includes the local database, server instances, worlds, backups, and mod files.

--- a/compose.https.yaml
+++ b/compose.https.yaml
@@ -5,7 +5,7 @@ services:
       - ./data/certbot/www:/var/www/certbot
       - ./data/certbot/conf:/etc/letsencrypt
 
-  nginx-https:
+  nginx:
     image: nginx:1.27-alpine
     pull_policy: missing
     restart: unless-stopped

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -45,6 +45,29 @@ http://服务器IP:3001
 cd ~/gamepanel-lite && sudo sh scripts/setup-https.sh your-domain.com your-email@example.com
 ```
 
+## 远程服务器维护
+
+生产环境只使用 `compose.prod.yaml`。启用 HTTPS 后，`compose.https.yaml` 会替换同一个 `nginx` 服务的端口和配置，不会再创建第二个 Nginx。
+
+在远程服务器更新控制平面镜像并重建有变化的服务：
+
+```bash
+cd ~/gamepanel-lite
+sudo sh scripts/manage.sh update
+```
+
+启动、停止和查看状态：
+
+```bash
+sudo sh scripts/manage.sh start
+sudo sh scripts/manage.sh stop
+sudo sh scripts/manage.sh status
+```
+
+`manage.sh` 会自动检测当前是 HTTP 还是 HTTPS 部署。它只管理面板、API、Nginx 和监控服务；帕鲁、饥荒等游戏容器仍由 GamePanel Lite 管理，不会在更新控制平面时被重建。
+
+不要在生产服务器叠加使用 `compose.yaml`。该文件用于本地开发，可能额外暴露 Web 端口。
+
 ## 数据保存
 
 GamePanel Lite 默认把数据保存在安装目录下的 `data/`，包括本地数据库、服务器实例、世界、备份和模组文件。

--- a/scripts/install-online.sh
+++ b/scripts/install-online.sh
@@ -28,7 +28,7 @@ tar -xzf "$TMP_DIR/gamepanel-lite.tar.gz" -C "$TMP_DIR/source" --strip-component
 
 echo "Installing to $INSTALL_DIR..."
 cp -R "$TMP_DIR/source/." "$INSTALL_DIR/"
-chmod +x "$INSTALL_DIR/scripts/install.sh" "$INSTALL_DIR/scripts/setup-https.sh" "$INSTALL_DIR/scripts/renew-https.sh" 2>/dev/null || true
+chmod +x "$INSTALL_DIR/scripts/install.sh" "$INSTALL_DIR/scripts/setup-https.sh" "$INSTALL_DIR/scripts/renew-https.sh" "$INSTALL_DIR/scripts/manage.sh" 2>/dev/null || true
 
 sh "$INSTALL_DIR/scripts/install.sh"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -46,3 +46,4 @@ echo
 echo "GamePanel Lite is starting."
 echo "Open: http://localhost:3001"
 echo "Data directory: $ROOT_DIR/data"
+echo "Manage with: sh scripts/manage.sh <start|update|stop|status>"

--- a/scripts/manage.sh
+++ b/scripts/manage.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+ACTION="${1:-status}"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker is required. Install Docker first, then run this script again."
+  exit 1
+fi
+
+if ! docker compose version >/dev/null 2>&1; then
+  echo "Docker Compose is required. Install the Docker Compose plugin first."
+  exit 1
+fi
+
+cd "$ROOT_DIR"
+set -- -f compose.prod.yaml
+MODE="HTTP"
+if [ -f "$ROOT_DIR/data/nginx/gamepanel-https.conf" ]; then
+  set -- "$@" -f compose.https.yaml
+  MODE="HTTPS"
+fi
+
+SERVICES="api web nginx gamepanel-exporter prometheus cadvisor node-exporter"
+
+case "$ACTION" in
+  start)
+    docker compose "$@" up -d --remove-orphans $SERVICES
+    ;;
+  update)
+    docker compose "$@" pull $SERVICES
+    docker compose "$@" up -d --remove-orphans $SERVICES
+    ;;
+  stop)
+    docker compose "$@" stop $SERVICES
+    ;;
+  status)
+    docker compose "$@" ps
+    ;;
+  *)
+    echo "Usage: sh scripts/manage.sh <start|update|stop|status>"
+    exit 1
+    ;;
+esac
+
+echo "GamePanel Lite control plane mode: $MODE"

--- a/scripts/renew-https.sh
+++ b/scripts/renew-https.sh
@@ -15,6 +15,6 @@ fi
 
 cd "$ROOT_DIR"
 docker compose -f compose.prod.yaml -f compose.https.yaml run --rm certbot renew
-docker compose -f compose.prod.yaml -f compose.https.yaml exec -T nginx-https nginx -s reload
+docker compose -f compose.prod.yaml -f compose.https.yaml exec -T nginx nginx -s reload
 
 echo "HTTPS certificate renewal check completed."

--- a/scripts/setup-https.sh
+++ b/scripts/setup-https.sh
@@ -59,8 +59,6 @@ sed "s/__GAMEPANEL_DOMAIN__/$DOMAIN/g" \
 
 cd "$ROOT_DIR"
 
-docker compose -f compose.prod.yaml -f compose.https.yaml stop nginx-https >/dev/null 2>&1 || true
-docker compose -f compose.prod.yaml -f compose.https.yaml rm -f nginx-https >/dev/null 2>&1 || true
 docker compose -f compose.prod.yaml pull api web nginx
 docker compose -f compose.prod.yaml up -d api web nginx
 
@@ -73,11 +71,11 @@ fi
 
 docker compose -f compose.prod.yaml -f compose.https.yaml run --rm certbot $CERTBOT_ARGS
 
-docker compose -f compose.prod.yaml stop nginx >/dev/null 2>&1 || true
-docker compose -f compose.prod.yaml rm -f nginx >/dev/null 2>&1 || true
-docker compose -f compose.prod.yaml -f compose.https.yaml up -d api web nginx-https gamepanel-exporter prometheus cadvisor node-exporter
+docker compose -f compose.prod.yaml -f compose.https.yaml up -d --remove-orphans --force-recreate nginx
+sh scripts/manage.sh start
 
 echo
 echo "HTTPS is ready."
 echo "Open: https://$DOMAIN"
 echo "Renew with: sh scripts/renew-https.sh"
+echo "Update with: sh scripts/manage.sh update"


### PR DESCRIPTION
## Summary
- make the HTTPS override replace the existing nginx service instead of creating nginx-https
- add one remote control-plane entry point: scripts/manage.sh
- automatically select HTTP or HTTPS mode for start/update/stop/status
- remove legacy proxy containers during HTTPS migration with --remove-orphans
- document the canonical production workflow and forbid mixing the development compose file

## Verification
- sh -n deployment scripts
- resolved HTTP Compose config contains one nginx service
- resolved HTTPS Compose config contains one nginx service on ports 80/443
- go test ./...
- go vet ./...
- pnpm --dir apps/web lint
- pnpm --dir apps/web typecheck
- pnpm --dir apps/web build