### PR TITLE
fix: keep control-plane start from pulling images

### DIFF
--- a/scripts/manage.sh
+++ b/scripts/manage.sh
@@ -26,11 +26,11 @@ SERVICES="api web nginx gamepanel-exporter prometheus cadvisor node-exporter"
 
 case "$ACTION" in
   start)
-    docker compose "$@" up -d --remove-orphans $SERVICES
+    docker compose "$@" up -d --remove-orphans --pull never $SERVICES
     ;;
   update)
     docker compose "$@" pull $SERVICES
-    docker compose "$@" up -d --remove-orphans $SERVICES
+    docker compose "$@" up -d --remove-orphans --pull never $SERVICES
     ;;
   stop)
     docker compose "$@" stop $SERVICES


### PR DESCRIPTION
## Summary
- make manage.sh start use locally installed images
- make update pull exactly once, then recreate from those images
- avoid unexpected API/Web updates during routine start

## Verification
- sh -n scripts/manage.sh
- production migration to the unified nginx service succeeded