### PR TITLE
feat: automate HTTPS certificate renewal

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,23 @@ If you have a domain pointed at the server, enable HTTPS:
 cd ~/gamepanel-lite && sudo sh scripts/setup-https.sh your-domain.com your-email@example.com
 ```
 
+On a systemd host, HTTPS setup installs a persistent daily certificate-renewal timer. Certbot only replaces a certificate after it enters the renewal window; the check itself is safe to run every day. Existing HTTPS installs can enable the timer with:
+
+```bash
+cd ~/gamepanel-lite
+sudo sh scripts/install-https-renewal-timer.sh
+sudo systemctl status gamepanel-lite-https-renewal.timer
+```
+
+Run a renewal check immediately or inspect its logs with:
+
+```bash
+sudo systemctl start gamepanel-lite-https-renewal.service
+sudo journalctl -u gamepanel-lite-https-renewal.service
+```
+
+The Certbot Compose service is isolated behind the `certificate` profile, so ordinary control-plane starts no longer create a stopped Certbot container.
+
 ## Remote Server Operations
 
 Update the control-plane images and recreate only changed services:

--- a/compose.https.yaml
+++ b/compose.https.yaml
@@ -1,6 +1,8 @@
 services:
   certbot:
     image: certbot/certbot:v2.11.0
+    profiles:
+      - certificate
     volumes:
       - ./data/certbot/www:/var/www/certbot
       - ./data/certbot/conf:/etc/letsencrypt

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -45,6 +45,23 @@ http://服务器IP:3001
 cd ~/gamepanel-lite && sudo sh scripts/setup-https.sh your-domain.com your-email@example.com
 ```
 
+在使用 systemd 的主机上，HTTPS 初始化会安装持久化的每日证书续期检查。Certbot 只有在证书进入续期窗口后才会真正替换证书，因此每天检查是安全的。已有 HTTPS 部署可以执行：
+
+```bash
+cd ~/gamepanel-lite
+sudo sh scripts/install-https-renewal-timer.sh
+sudo systemctl status gamepanel-lite-https-renewal.timer
+```
+
+立即执行一次续期检查或查看日志：
+
+```bash
+sudo systemctl start gamepanel-lite-https-renewal.service
+sudo journalctl -u gamepanel-lite-https-renewal.service
+```
+
+Certbot Compose 服务已放入 `certificate` profile，普通控制平面启动不会再创建一个退出状态的 Certbot 容器。
+
 ## 远程服务器维护
 
 生产环境只使用 `compose.prod.yaml`。启用 HTTPS 后，`compose.https.yaml` 会替换同一个 `nginx` 服务的端口和配置，不会再创建第二个 Nginx。

--- a/docs/goals/V1_PROGRESS.md
+++ b/docs/goals/V1_PROGRESS.md
@@ -1,5 +1,11 @@
 # V1 Progress
 
+## 2026-07-16
+
+- Isolated Certbot behind an opt-in Compose profile so normal control-plane operations do not create a misleading exited container.
+- Added a reusable systemd installer for persistent daily HTTPS renewal checks, using a root-owned runner/config with randomized scheduling and journald logs.
+- Integrated automatic renewal setup into the HTTPS bootstrap flow and documented installation, status, manual checks, and logs in English and Chinese.
+
 ## 2026-07-15
 
 - Added persistent asynchronous Palworld update checks and installs with explicit task status, stage, progress, build IDs, and failure details.

--- a/scripts/https-renewal-runner.sh
+++ b/scripts/https-renewal-runner.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env sh
+set -eu
+
+: "${GAMEPANEL_DOCKER_BIN:?Missing Docker executable path}"
+: "${GAMEPANEL_CERTBOT_IMAGE:?Missing Certbot image}"
+: "${GAMEPANEL_CERTBOT_WWW:?Missing Certbot webroot path}"
+: "${GAMEPANEL_CERTBOT_CONF:?Missing Certbot configuration path}"
+: "${GAMEPANEL_COMPOSE_PROJECT:?Missing Compose project name}"
+
+if [ ! -x "$GAMEPANEL_DOCKER_BIN" ]; then
+  echo "Docker executable is unavailable: $GAMEPANEL_DOCKER_BIN"
+  exit 1
+fi
+
+for path in "$GAMEPANEL_CERTBOT_WWW" "$GAMEPANEL_CERTBOT_CONF"; do
+  if [ ! -d "$path" ] || [ "$(readlink -f "$path")" != "$path" ]; then
+    echo "Certificate data path is missing or has become a symlink: $path"
+    exit 1
+  fi
+done
+
+"$GAMEPANEL_DOCKER_BIN" run --rm --pull=missing \
+  --mount "type=bind,src=$GAMEPANEL_CERTBOT_WWW,dst=/var/www/certbot" \
+  --mount "type=bind,src=$GAMEPANEL_CERTBOT_CONF,dst=/etc/letsencrypt" \
+  "$GAMEPANEL_CERTBOT_IMAGE" renew
+
+set -- $("$GAMEPANEL_DOCKER_BIN" ps \
+  --filter "label=com.docker.compose.project=$GAMEPANEL_COMPOSE_PROJECT" \
+  --filter "label=com.docker.compose.service=nginx" \
+  --format '{{.ID}}')
+if [ "$#" -ne 1 ]; then
+  echo "Expected exactly one running GamePanel Lite Nginx container, found $#."
+  exit 1
+fi
+
+"$GAMEPANEL_DOCKER_BIN" exec "$1" nginx -t
+"$GAMEPANEL_DOCKER_BIN" exec "$1" nginx -s reload
+
+echo "HTTPS certificate renewal check completed."

--- a/scripts/install-https-renewal-timer.sh
+++ b/scripts/install-https-renewal-timer.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+RUNNER_SOURCE="$ROOT_DIR/scripts/https-renewal-runner.sh"
+UNIT_NAME="gamepanel-lite-https-renewal"
+CONFIG_DIR="/etc/gamepanel-lite"
+CONFIG_FILE="$CONFIG_DIR/https-renewal.env"
+RUNNER_DIR="/usr/local/libexec/gamepanel-lite"
+RUNNER_FILE="$RUNNER_DIR/https-renewal"
+SERVICE_FILE="/etc/systemd/system/$UNIT_NAME.service"
+TIMER_FILE="/etc/systemd/system/$UNIT_NAME.timer"
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "Root privileges are required. Run: sudo sh scripts/install-https-renewal-timer.sh"
+  exit 1
+fi
+
+if ! command -v systemctl >/dev/null 2>&1 || [ ! -d /run/systemd/system ]; then
+  echo "A running systemd service manager is required for the automatic HTTPS renewal timer."
+  exit 1
+fi
+
+if ! systemctl show-environment >/dev/null 2>&1; then
+  echo "The systemd service manager is not reachable."
+  exit 1
+fi
+
+if ! command -v docker >/dev/null 2>&1 || ! docker compose version >/dev/null 2>&1; then
+  echo "Docker with the Compose plugin is required for automatic HTTPS renewal."
+  exit 1
+fi
+
+if [ ! -f "$ROOT_DIR/data/nginx/gamepanel-https.conf" ]; then
+  echo "HTTPS is not configured. Run scripts/setup-https.sh before installing the renewal timer."
+  exit 1
+fi
+
+if [ ! -f "$RUNNER_SOURCE" ]; then
+  echo "Renewal runner not found: $RUNNER_SOURCE"
+  exit 1
+fi
+
+# Values written to the root-owned environment file are deliberately restricted
+# so systemd and Docker receive unambiguous arguments.
+case "$ROOT_DIR" in
+  *[!A-Za-z0-9_./-]*)
+    echo "The install path contains unsupported characters: $ROOT_DIR"
+    exit 1
+    ;;
+esac
+
+CERTBOT_ROOT="$ROOT_DIR/data/certbot"
+CERTBOT_WWW="$CERTBOT_ROOT/www"
+CERTBOT_CONF="$CERTBOT_ROOT/conf"
+for path in "$CERTBOT_ROOT" "$CERTBOT_WWW" "$CERTBOT_CONF"; do
+  if [ ! -d "$path" ] || [ "$(readlink -f "$path")" != "$path" ]; then
+    echo "Certificate data must be an existing directory without symlinks: $path"
+    exit 1
+  fi
+done
+
+cd "$ROOT_DIR"
+set -- $(docker compose -f compose.prod.yaml -f compose.https.yaml ps -q nginx)
+if [ "$#" -ne 1 ]; then
+  echo "Exactly one running HTTPS Nginx container is required before installing the timer."
+  exit 1
+fi
+NGINX_CONTAINER="$1"
+COMPOSE_PROJECT=$(docker inspect --format '{{ index .Config.Labels "com.docker.compose.project" }}' "$NGINX_CONTAINER")
+case "$COMPOSE_PROJECT" in
+  ""|*[!A-Za-z0-9_.-]*)
+    echo "Unable to determine a safe Compose project name from the Nginx container."
+    exit 1
+    ;;
+esac
+
+DOCKER_BIN=$(command -v docker)
+case "$DOCKER_BIN" in
+  *[!A-Za-z0-9_./-]*)
+    echo "Docker executable path contains unsupported characters: $DOCKER_BIN"
+    exit 1
+    ;;
+esac
+
+TMP_DIR=$(mktemp -d)
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup 0
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+cat > "$TMP_DIR/https-renewal.env" <<EOF
+GAMEPANEL_DOCKER_BIN=$DOCKER_BIN
+GAMEPANEL_CERTBOT_IMAGE=certbot/certbot:v2.11.0
+GAMEPANEL_CERTBOT_WWW=$CERTBOT_WWW
+GAMEPANEL_CERTBOT_CONF=$CERTBOT_CONF
+GAMEPANEL_COMPOSE_PROJECT=$COMPOSE_PROJECT
+EOF
+
+cat > "$TMP_DIR/$UNIT_NAME.service" <<EOF
+[Unit]
+Description=Check and renew the GamePanel Lite HTTPS certificate
+Wants=network-online.target docker.service
+After=network-online.target docker.service
+
+[Service]
+Type=oneshot
+EnvironmentFile=$CONFIG_FILE
+ExecStart=$RUNNER_FILE
+TimeoutStartSec=45min
+UMask=0022
+EOF
+
+cat > "$TMP_DIR/$UNIT_NAME.timer" <<EOF
+[Unit]
+Description=Daily GamePanel Lite HTTPS certificate renewal check
+
+[Timer]
+OnCalendar=daily
+RandomizedDelaySec=6h
+Persistent=true
+Unit=$UNIT_NAME.service
+
+[Install]
+WantedBy=timers.target
+EOF
+
+install -d -m 0755 "$CONFIG_DIR" "$RUNNER_DIR"
+install -m 0600 "$TMP_DIR/https-renewal.env" "$CONFIG_FILE"
+install -m 0755 "$RUNNER_SOURCE" "$RUNNER_FILE"
+install -m 0644 "$TMP_DIR/$UNIT_NAME.service" "$SERVICE_FILE"
+install -m 0644 "$TMP_DIR/$UNIT_NAME.timer" "$TIMER_FILE"
+
+systemctl daemon-reload
+if command -v systemd-analyze >/dev/null 2>&1; then
+  systemd-analyze verify "$SERVICE_FILE" "$TIMER_FILE"
+fi
+systemctl enable --now "$UNIT_NAME.timer"
+
+echo "Automatic HTTPS renewal is enabled."
+systemctl show "$UNIT_NAME.timer" \
+  --property=ActiveState \
+  --property=NextElapseUSecRealtime \
+  --no-pager
+echo "Run a check now with: sudo systemctl start $UNIT_NAME.service"
+echo "View logs with: sudo journalctl -u $UNIT_NAME.service"

--- a/scripts/install-online.sh
+++ b/scripts/install-online.sh
@@ -28,7 +28,7 @@ tar -xzf "$TMP_DIR/gamepanel-lite.tar.gz" -C "$TMP_DIR/source" --strip-component
 
 echo "Installing to $INSTALL_DIR..."
 cp -R "$TMP_DIR/source/." "$INSTALL_DIR/"
-chmod +x "$INSTALL_DIR/scripts/install.sh" "$INSTALL_DIR/scripts/setup-https.sh" "$INSTALL_DIR/scripts/renew-https.sh" "$INSTALL_DIR/scripts/manage.sh" 2>/dev/null || true
+chmod +x "$INSTALL_DIR/scripts/install.sh" "$INSTALL_DIR/scripts/setup-https.sh" "$INSTALL_DIR/scripts/renew-https.sh" "$INSTALL_DIR/scripts/install-https-renewal-timer.sh" "$INSTALL_DIR/scripts/https-renewal-runner.sh" "$INSTALL_DIR/scripts/manage.sh" 2>/dev/null || true
 
 sh "$INSTALL_DIR/scripts/install.sh"
 

--- a/scripts/renew-https.sh
+++ b/scripts/renew-https.sh
@@ -15,6 +15,7 @@ fi
 
 cd "$ROOT_DIR"
 docker compose -f compose.prod.yaml -f compose.https.yaml run --rm certbot renew
+docker compose -f compose.prod.yaml -f compose.https.yaml exec -T nginx nginx -t
 docker compose -f compose.prod.yaml -f compose.https.yaml exec -T nginx nginx -s reload
 
 echo "HTTPS certificate renewal check completed."

--- a/scripts/setup-https.sh
+++ b/scripts/setup-https.sh
@@ -74,8 +74,28 @@ docker compose -f compose.prod.yaml -f compose.https.yaml run --rm certbot $CERT
 docker compose -f compose.prod.yaml -f compose.https.yaml up -d --remove-orphans --force-recreate nginx
 sh scripts/manage.sh start
 
+TIMER_AVAILABLE="false"
+TIMER_INSTALLED="false"
+if command -v systemctl >/dev/null 2>&1 && [ -d /run/systemd/system ]; then
+  TIMER_AVAILABLE="true"
+  if [ "$(id -u)" -eq 0 ]; then
+    if sh scripts/install-https-renewal-timer.sh; then
+      TIMER_INSTALLED="true"
+    else
+      echo "Warning: HTTPS is ready, but the automatic renewal timer could not be installed."
+    fi
+  fi
+fi
+
 echo
 echo "HTTPS is ready."
 echo "Open: https://$DOMAIN"
 echo "Renew with: sh scripts/renew-https.sh"
+if [ "$TIMER_INSTALLED" != "true" ]; then
+  if [ "$TIMER_AVAILABLE" = "true" ]; then
+    echo "Enable automatic renewal with: sudo sh scripts/install-https-renewal-timer.sh"
+  else
+    echo "No running systemd manager was detected; schedule scripts/renew-https.sh with your host scheduler."
+  fi
+fi
 echo "Update with: sh scripts/manage.sh update"


### PR DESCRIPTION
## Summary
- isolate the one-shot Certbot service behind a certificate Compose profile
- install a persistent daily systemd renewal timer with a root-owned runner and configuration
- validate Nginx before reload and document setup/status/log commands in English and Chinese

## Verification
- sh syntax checks
- Compose config and profile checks
- mocked renewal runner flow
- go test ./...
- go vet ./...
- frontend lint, typecheck, 79 tests, and production build
- independent security review with all P1 findings resolved