### PR TITLE
fix: repair Palworld log FIFO permissions

### DIFF
--- a/docker/palworld/Dockerfile
+++ b/docker/palworld/Dockerfile
@@ -1,6 +1,16 @@
 ARG PALWORLD_RUNTIME_VERSION=v2.5.0
 FROM thijsvanloef/palworld-server-docker:${PALWORLD_RUNTIME_VERSION}
 
+COPY docker/palworld/patch_pal_logger.py /tmp/patch_pal_logger.py
+
+# The upstream logger is started asynchronously as root. It can recreate its
+# private FIFO after init.sh has already chowned /home/steam, leaving the game
+# helper unable to write log events. Patch the logger to publish a correctly
+# owned FIFO atomically and fail the build if the upstream block changes.
+RUN python3 /tmp/patch_pal_logger.py /home/steam/server/pal_logger.py \
+    && python3 -m py_compile /home/steam/server/pal_logger.py \
+    && rm -rf /tmp/patch_pal_logger.py /home/steam/server/__pycache__
+
 # SteamCMD can replace PalServer.sh without preserving its executable bit.
 # The upstream start script validates the bit immediately after updating, so
 # repair it after InstallServer and before STARTCOMMAND is validated.

--- a/docker/palworld/README.md
+++ b/docker/palworld/README.md
@@ -2,6 +2,13 @@
 
 This image packages the stable `thijsvanloef/palworld-server-docker` runtime under the GamePanel Lite image namespace. GamePanel sets `UPDATE_ON_BOOT=false` after the initial installation so ordinary container restarts reuse the installed Palworld Dedicated Server files instead of verifying roughly 5 GB through SteamCMD every time. Runtime image upgrades are managed explicitly by GamePanel.
 
+The image also fixes an upstream startup race in `pal_logger.py`. The upstream
+logger can recreate its private log FIFO as `root:root` with mode `0600` after
+the initialization script has already changed `/home/steam` to the configured
+`PUID` and `PGID`. GamePanel's build-time patch creates a private temporary FIFO,
+sets its final owner and mode, and atomically publishes it. The build fails if
+the expected upstream code changes, preventing a silently stale patch.
+
 Build and load the current version for the local Docker architecture:
 
 ```bash
@@ -18,4 +25,29 @@ Override the upstream runtime tag when testing a newer release:
 
 ```bash
 PALWORLD_RUNTIME_VERSION=v2.5.0 scripts/build-game-images.sh palworld --load
+```
+
+Keep the upstream base version separate from an immutable GamePanel image tag:
+
+```bash
+PALWORLD_RUNTIME_VERSION=v2.5.0 \
+PALWORLD_IMAGE_VERSION=v2.5.0-gamepanel.1 \
+scripts/build-game-images.sh palworld --platform linux/amd64 --push
+```
+
+Run the build-time patch tests without Docker:
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 python3 -m unittest docker/palworld/test_patch_pal_logger.py
+```
+
+After loading an amd64 image, exercise the patched logger as root while a
+non-root game helper writes to the FIFO:
+
+```bash
+docker run --rm --platform linux/amd64 \
+  --entrypoint /bin/bash \
+  -v "$PWD/docker/palworld/test_fifo_runtime.sh:/tmp/test_fifo_runtime.sh:ro" \
+  smartcat99999/palworld-server:v2.5.0-gamepanel.1 \
+  /tmp/test_fifo_runtime.sh
 ```

--- a/docker/palworld/patch_pal_logger.py
+++ b/docker/palworld/patch_pal_logger.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Patch the upstream Palworld logger's FIFO setup without vendoring it."""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+
+PATCH_MARKER = "# GamePanel Lite: publish the FIFO with its final owner atomically."
+
+UPSTREAM_BLOCK = '''# Setup FIFO
+if os.path.exists(FIFO_PATH):
+    try:
+        os.remove(FIFO_PATH)
+    except OSError:
+        pass
+try:
+    os.mkfifo(FIFO_PATH)
+    # Use 0o600 to restrict access to the owner only.
+    # The owner will be updated to 'steam' by init.sh via chown, ensuring correct access permissions.
+    # We avoid 0o666 to prevent security warnings (e.g. CodeFactor).
+    os.chmod(FIFO_PATH, 0o600)
+except OSError as e:
+    if e.errno != errno.EEXIST:
+        raise
+'''
+
+PATCHED_BLOCK = '''# Setup FIFO
+# GamePanel Lite: publish the FIFO with its final owner atomically.
+# init.sh starts this logger asynchronously, so its earlier recursive chown can
+# finish before mkfifo runs. Publishing a root-owned 0600 FIFO even briefly can
+# make the steam helper lose log events with EACCES.
+fifo_temp_path = f"{FIFO_PATH}.{os.getpid()}.tmp"
+try:
+    if os.path.lexists(fifo_temp_path):
+        os.remove(fifo_temp_path)
+    os.mkfifo(fifo_temp_path, 0o600)
+    os.chmod(fifo_temp_path, 0o600)
+    if os.geteuid() == 0:
+        try:
+            fifo_uid = int(os.environ.get("PUID", "1000"), 10)
+            fifo_gid = int(os.environ.get("PGID", "1000"), 10)
+        except ValueError as exc:
+            raise RuntimeError("PUID and PGID must be decimal integers") from exc
+        if fifo_uid < 0 or fifo_gid < 0:
+            raise RuntimeError("PUID and PGID must not be negative")
+        os.chown(fifo_temp_path, fifo_uid, fifo_gid)
+    os.replace(fifo_temp_path, FIFO_PATH)
+except BaseException:
+    try:
+        if os.path.lexists(fifo_temp_path):
+            os.remove(fifo_temp_path)
+    except OSError:
+        pass
+    raise
+'''
+
+
+def patch(path: pathlib.Path) -> bool:
+    source = path.read_text(encoding="utf-8")
+    if PATCH_MARKER in source:
+        return False
+    matches = source.count(UPSTREAM_BLOCK)
+    if matches != 1:
+        raise RuntimeError(
+            f"expected exactly one upstream FIFO setup block in {path}, found {matches}"
+        )
+    path.write_text(source.replace(UPSTREAM_BLOCK, PATCHED_BLOCK), encoding="utf-8")
+    return True
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(f"usage: {argv[0]} PAL_LOGGER_PATH", file=sys.stderr)
+        return 2
+    target = pathlib.Path(argv[1])
+    changed = patch(target)
+    print(f"{'patched' if changed else 'already patched'} {target}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/docker/palworld/test_fifo_runtime.sh
+++ b/docker/palworld/test_fifo_runtime.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly fifo=/home/steam/server/.palserver_log_fifo
+readonly stdout_file=/tmp/pal-logger.stdout
+readonly stderr_file=/tmp/pal-logger.stderr
+readonly test_uid=12001
+readonly test_gid=12002
+
+rm -f "${fifo}" "${stdout_file}" "${stderr_file}"
+# Mirror init.sh changing the steam home to the configured runtime identity.
+chown "${test_uid}:${test_gid}" /home/steam
+
+tail -f /dev/null | env PUID="${test_uid}" PGID="${test_gid}" \
+  python3 /home/steam/server/pal_logger.py >"${stdout_file}" 2>"${stderr_file}" &
+logger_pid=$!
+
+cleanup() {
+  kill "${logger_pid}" 2>/dev/null || true
+  wait "${logger_pid}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+for _ in $(seq 1 100); do
+  if [[ -p "${fifo}" ]]; then
+    break
+  fi
+  sleep 0.05
+done
+
+[[ -p "${fifo}" ]]
+[[ "$(stat -c '%u:%g %a' "${fifo}")" == "${test_uid}:${test_gid} 600" ]]
+
+python3 -c 'import os; os.setgid(12002); os.setuid(12001); fd = os.open("/home/steam/server/.palserver_log_fifo", os.O_WRONLY); os.write(fd, b"LOG:gamepanel-fifo-probe\nLOG_FLUSH\n"); os.close(fd)'
+
+for _ in $(seq 1 100); do
+  if grep -q 'gamepanel-fifo-probe' "${stdout_file}"; then
+    break
+  fi
+  sleep 0.05
+done
+
+grep -q 'gamepanel-fifo-probe' "${stdout_file}"
+if grep -Eqi 'permission denied|failed to flush log to fifo' "${stderr_file}"; then
+  cat "${stderr_file}" >&2
+  exit 1
+fi
+
+echo "FIFO runtime test passed: $(stat -c '%u:%g %a %F' "${fifo}")"

--- a/docker/palworld/test_patch_pal_logger.py
+++ b/docker/palworld/test_patch_pal_logger.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+SCRIPT_PATH = pathlib.Path(__file__).with_name("patch_pal_logger.py")
+SPEC = importlib.util.spec_from_file_location("patch_pal_logger", SCRIPT_PATH)
+assert SPEC is not None and SPEC.loader is not None
+PATCHER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(PATCHER)
+
+
+class PatchPalLoggerTest(unittest.TestCase):
+    def test_patch_is_exact_and_idempotent(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = pathlib.Path(directory, "pal_logger.py")
+            path.write_text("import os\nimport errno\n\n" + PATCHER.UPSTREAM_BLOCK, encoding="utf-8")
+
+            self.assertTrue(PATCHER.patch(path))
+            first = path.read_text(encoding="utf-8")
+            self.assertIn(PATCHER.PATCH_MARKER, first)
+            self.assertIn("os.chown(fifo_temp_path, fifo_uid, fifo_gid)", first)
+            self.assertIn("os.replace(fifo_temp_path, FIFO_PATH)", first)
+            self.assertFalse(PATCHER.patch(path))
+            self.assertEqual(first, path.read_text(encoding="utf-8"))
+
+    def test_patch_rejects_changed_upstream_block(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = pathlib.Path(directory, "pal_logger.py")
+            path.write_text("# upstream changed\n", encoding="utf-8")
+            with self.assertRaisesRegex(RuntimeError, "found 0"):
+                PATCHER.patch(path)
+
+    def test_non_root_fifo_is_atomically_published_with_private_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fifo = pathlib.Path(directory, "events.fifo")
+            script = pathlib.Path(directory, "fixture.py")
+            source = (
+                "import errno\nimport os\nimport stat\n"
+                f"FIFO_PATH = {str(fifo)!r}\n"
+                + PATCHER.UPSTREAM_BLOCK
+                + "result = os.stat(FIFO_PATH)\n"
+                + "assert stat.S_ISFIFO(result.st_mode)\n"
+                + "assert result.st_uid == os.geteuid()\n"
+                + "assert result.st_gid == os.getegid()\n"
+                + "assert stat.S_IMODE(result.st_mode) == 0o600\n"
+            )
+            script.write_text(source, encoding="utf-8")
+            PATCHER.patch(script)
+            subprocess.run([sys.executable, str(script)], check=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/goals/V1_PROGRESS.md
+++ b/docs/goals/V1_PROGRESS.md
@@ -2,6 +2,9 @@
 
 ## 2026-07-16
 
+- Fixed the Palworld runtime logger FIFO ownership race by atomically publishing
+  a private FIFO owned by the configured `PUID` and `PGID`, with a strict
+  build-time upstream compatibility check and focused patch tests.
 - Isolated Certbot behind an opt-in Compose profile so normal control-plane operations do not create a misleading exited container.
 - Added a reusable systemd installer for persistent daily HTTPS renewal checks, using a root-owned runner/config with randomized scheduling and journald logs.
 - Integrated automatic renewal setup into the HTTPS bootstrap flow and documented installation, status, manual checks, and logs in English and Chinese.

--- a/scripts/build-game-images.sh
+++ b/scripts/build-game-images.sh
@@ -155,13 +155,14 @@ build_dst() {
 }
 
 build_palworld() {
-  local version="${PALWORLD_RUNTIME_VERSION:-v2.5.0}"
-  local image="${registry}/palworld-server:${version}"
+  local runtime_version="${PALWORLD_RUNTIME_VERSION:-v2.5.0}"
+  local image_version="${PALWORLD_IMAGE_VERSION:-${runtime_version}}"
+  local image="${registry}/palworld-server:${image_version}"
 
   echo "==> Building ${image}"
   docker "${buildx_args[@]}" \
     -f docker/palworld/Dockerfile \
-    --build-arg "PALWORLD_RUNTIME_VERSION=${version}" \
+    --build-arg "PALWORLD_RUNTIME_VERSION=${runtime_version}" \
     -t "${image}" \
     "${root_dir}"
 }


### PR DESCRIPTION
## Summary
- patch the upstream Palworld logger to atomically publish a private FIFO with the configured PUID/PGID
- fail image builds when the upstream FIFO block changes
- separate upstream runtime version from distributable image tag and document the release flow
- add focused patch and runtime FIFO tests

## Verification
- PYTHONDONTWRITEBYTECODE=1 python3 -m unittest docker/palworld/test_patch_pal_logger.py
- bash -n scripts/build-game-images.sh docker/palworld/test_fifo_runtime.sh
- docker buildx build --platform linux/amd64 ... --load
- FIFO runtime test: root logger, UID/GID 12001:12002 writer, mode 0600
- go test ./...
- go vet ./...
- pnpm --dir apps/web lint
- pnpm --dir apps/web typecheck
- pnpm --dir apps/web test
- pnpm --dir apps/web build
- git diff --check