### PR TITLE
fix: expose DST shard ports

### DIFF
--- a/apps/api/internal/domain/runtime.go
+++ b/apps/api/internal/domain/runtime.go
@@ -6,8 +6,15 @@ type WorkloadResources struct {
 }
 
 type WorkloadNetwork struct {
-	Port     int    `json:"port,omitempty"`
-	HostPort int    `json:"hostPort,omitempty"`
+	Port            int            `json:"port,omitempty"`
+	HostPort        int            `json:"hostPort,omitempty"`
+	Protocol        string         `json:"protocol,omitempty"`
+	AdditionalPorts []WorkloadPort `json:"additionalPorts,omitempty"`
+}
+
+type WorkloadPort struct {
+	Port     int    `json:"port"`
+	HostPort int    `json:"hostPort"`
 	Protocol string `json:"protocol,omitempty"`
 }
 
@@ -29,10 +36,11 @@ type WorkloadSpec struct {
 }
 
 type ProviderRuntimeConfig struct {
-	Port       int             `json:"port,omitempty"`
-	Protocol   string          `json:"protocol,omitempty"`
-	ConfigText string          `json:"configText,omitempty"`
-	Options    WorkloadOptions `json:"options,omitempty"`
+	Port            int             `json:"port,omitempty"`
+	AdditionalPorts []int           `json:"additionalPorts,omitempty"`
+	Protocol        string          `json:"protocol,omitempty"`
+	ConfigText      string          `json:"configText,omitempty"`
+	Options         WorkloadOptions `json:"options,omitempty"`
 }
 
 type WorkloadStatus struct {

--- a/apps/api/internal/provider/dst/provider.go
+++ b/apps/api/internal/provider/dst/provider.go
@@ -253,10 +253,15 @@ func (p Provider) RuntimeConfigForResource(server domain.GameServer) (domain.Pro
 		options.Files[clusterDir+"/Caves/leveldataoverride.lua"] = renderLevelDataOverrideLua("cave", config.Caves.Preset, config.Caves.Overrides)
 		options.Files[clusterDir+"/Caves/modoverrides.lua"] = renderModOverrides(config.Mods.WorkshopIDs)
 	}
+	additionalPorts := []int(nil)
+	if config.Caves != nil && config.Caves.Enabled {
+		additionalPorts = []int{config.Port + 1}
+	}
 	return domain.ProviderRuntimeConfig{
-		Port:     config.Port,
-		Protocol: options.PortProtocol,
-		Options:  workloadOptions(options),
+		Port:            config.Port,
+		AdditionalPorts: additionalPorts,
+		Protocol:        options.PortProtocol,
+		Options:         workloadOptions(options),
 	}, nil
 }
 

--- a/apps/api/internal/provider/dst/provider_test.go
+++ b/apps/api/internal/provider/dst/provider_test.go
@@ -167,6 +167,9 @@ func TestServerRuntimeUsesSemanticConfigPayload(t *testing.T) {
 	if runtimeConfig.ConfigText != "" {
 		t.Fatalf("DST resource runtime should not render legacy serverconfig.txt, got %q", runtimeConfig.ConfigText)
 	}
+	if len(runtimeConfig.AdditionalPorts) != 1 || runtimeConfig.AdditionalPorts[0] != 11000 {
+		t.Fatalf("expected Caves UDP port 11000, got %v", runtimeConfig.AdditionalPorts)
+	}
 	options := runtimeConfig.Options
 	if !strings.Contains(options.Files["dst/Payload Cluster/cluster.ini"], "game_mode = endless") {
 		t.Fatalf("expected payload game mode in cluster.ini, got:\n%s", options.Files["dst/Payload Cluster/cluster.ini"])

--- a/apps/api/internal/runtime/docker/adapter.go
+++ b/apps/api/internal/runtime/docker/adapter.go
@@ -79,7 +79,7 @@ func (a *Adapter) createContainer(ctx context.Context, spec runtime.ContainerSpe
 	}
 	hostConfig := &container.HostConfig{
 		Binds:        binds,
-		PortBindings: natPortMap(spec.Port, spec.HostPort, spec.Options.PortProtocol),
+		PortBindings: natPortMaps(spec),
 		// Docker remembers containers stopped explicitly by the user. With
 		// unless-stopped, desired-running game servers recover after a host or
 		// daemon restart while instances stopped through GamePanel stay stopped.
@@ -95,7 +95,7 @@ func (a *Adapter) createContainer(ctx context.Context, spec runtime.ContainerSpe
 		Image:        spec.Image,
 		Env:          spec.Options.Env,
 		Cmd:          spec.Options.Cmd,
-		ExposedPorts: natPortSet(spec.Port, spec.Options.PortProtocol),
+		ExposedPorts: natPortSets(spec),
 		OpenStdin:    true,
 		AttachStdin:  true,
 		Labels: map[string]string{

--- a/apps/api/internal/runtime/docker/adapter_test.go
+++ b/apps/api/internal/runtime/docker/adapter_test.go
@@ -92,6 +92,23 @@ func TestNatPortSetSupportsUdp(t *testing.T) {
 	}
 }
 
+func TestNatPortMapsIncludesAdditionalUdpPort(t *testing.T) {
+	ports := natPortMaps(runtime.ContainerSpec{
+		Port:     10999,
+		HostPort: 10999,
+		Options:  runtime.ContainerOptions{PortProtocol: "udp"},
+		AdditionalPorts: []runtime.ContainerPort{
+			{Port: 11000, HostPort: 11000, Protocol: "udp"},
+		},
+	})
+	if got := ports["10999/udp"]; len(got) != 1 || got[0].HostPort != "10999" {
+		t.Fatalf("expected Master UDP mapping, got %v", got)
+	}
+	if got := ports["11000/udp"]; len(got) != 1 || got[0].HostPort != "11000" {
+		t.Fatalf("expected Caves UDP mapping, got %v", got)
+	}
+}
+
 func TestPrepareDataMountsRepairsExistingDirectoryPermissions(t *testing.T) {
 	dataDir := t.TempDir()
 	if err := os.Chmod(dataDir, 0o755); err != nil {

--- a/apps/api/internal/runtime/docker/data.go
+++ b/apps/api/internal/runtime/docker/data.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/docker/go-connections/nat"
+	"github.com/smartcat999/game-panel-lite/apps/api/internal/runtime"
 )
 
 func writeDataFile(dataDir string, name string, content string) error {
@@ -165,6 +166,31 @@ func natPortMap(containerPort int, hostPort int, protocol string) nat.PortMap {
 
 func natPortSet(containerPort int, protocol string) nat.PortSet {
 	return nat.PortSet{nat.Port(fmt.Sprintf("%d/%s", containerPort, normalizePortProtocol(protocol))): struct{}{}}
+}
+
+func natPortMaps(spec runtime.ContainerSpec) nat.PortMap {
+	ports := natPortMap(spec.Port, spec.HostPort, spec.Options.PortProtocol)
+	for _, port := range spec.AdditionalPorts {
+		protocol := port.Protocol
+		if strings.TrimSpace(protocol) == "" {
+			protocol = spec.Options.PortProtocol
+		}
+		p := nat.Port(fmt.Sprintf("%d/%s", port.Port, normalizePortProtocol(protocol)))
+		ports[p] = []nat.PortBinding{{HostIP: "0.0.0.0", HostPort: fmt.Sprintf("%d", port.HostPort)}}
+	}
+	return ports
+}
+
+func natPortSets(spec runtime.ContainerSpec) nat.PortSet {
+	ports := natPortSet(spec.Port, spec.Options.PortProtocol)
+	for _, port := range spec.AdditionalPorts {
+		protocol := port.Protocol
+		if strings.TrimSpace(protocol) == "" {
+			protocol = spec.Options.PortProtocol
+		}
+		ports[nat.Port(fmt.Sprintf("%d/%s", port.Port, normalizePortProtocol(protocol)))] = struct{}{}
+	}
+	return ports
 }
 
 func normalizePortProtocol(protocol string) string {

--- a/apps/api/internal/runtime/runtime.go
+++ b/apps/api/internal/runtime/runtime.go
@@ -9,15 +9,22 @@ import (
 )
 
 type ContainerSpec struct {
-	InstanceID string
-	Name       string
-	Image      string
-	Port       int
-	HostPort   int
-	Resources  ContainerResources
-	DataDir    string
-	ConfigText string
-	Options    ContainerOptions
+	InstanceID      string
+	Name            string
+	Image           string
+	Port            int
+	HostPort        int
+	AdditionalPorts []ContainerPort
+	Resources       ContainerResources
+	DataDir         string
+	ConfigText      string
+	Options         ContainerOptions
+}
+
+type ContainerPort struct {
+	Port     int
+	HostPort int
+	Protocol string
 }
 
 type ContainerResources struct {
@@ -178,6 +185,13 @@ func ContainerSpecFromWorkload(spec domain.WorkloadSpec) ContainerSpec {
 		Image:      spec.Image,
 		Port:       spec.Network.Port,
 		HostPort:   spec.Network.HostPort,
+		AdditionalPorts: func() []ContainerPort {
+			ports := make([]ContainerPort, 0, len(spec.Network.AdditionalPorts))
+			for _, port := range spec.Network.AdditionalPorts {
+				ports = append(ports, ContainerPort{Port: port.Port, HostPort: port.HostPort, Protocol: port.Protocol})
+			}
+			return ports
+		}(),
 		Resources: ContainerResources{
 			CPULimitCores: spec.Resources.CPULimitCores,
 			MemoryLimitMB: spec.Resources.MemoryLimitMB,
@@ -211,6 +225,13 @@ func WorkloadSpecFromContainer(spec ContainerSpec) domain.WorkloadSpec {
 			Port:     spec.Port,
 			HostPort: spec.HostPort,
 			Protocol: spec.Options.PortProtocol,
+			AdditionalPorts: func() []domain.WorkloadPort {
+				ports := make([]domain.WorkloadPort, 0, len(spec.AdditionalPorts))
+				for _, port := range spec.AdditionalPorts {
+					ports = append(ports, domain.WorkloadPort{Port: port.Port, HostPort: port.HostPort, Protocol: port.Protocol})
+				}
+				return ports
+			}(),
 		},
 		Resources: domain.WorkloadResources{
 			CPULimitCores: spec.Resources.CPULimitCores,

--- a/apps/api/internal/server/workload.go
+++ b/apps/api/internal/server/workload.go
@@ -60,14 +60,23 @@ func (b *ProviderWorkloadBuilder) BuildWorkloadSpec(ctx context.Context, server 
 	for name, content := range runtimeConfig.Options.Files {
 		files[name] = content
 	}
+	additionalPorts := make([]domain.WorkloadPort, 0, len(runtimeConfig.AdditionalPorts))
+	for _, port := range runtimeConfig.AdditionalPorts {
+		additionalPorts = append(additionalPorts, domain.WorkloadPort{
+			Port:     port,
+			HostPort: server.Spec.Network.HostPort + (port - runtimeConfig.Port),
+			Protocol: runtimeConfig.Protocol,
+		})
+	}
 	return domain.WorkloadSpec{
 		ServerID: server.ID,
 		Name:     server.Name,
 		Image:    gameProvider.ImageFor(version),
 		Network: domain.WorkloadNetwork{
-			Port:     runtimeConfig.Port,
-			HostPort: server.Spec.Network.HostPort,
-			Protocol: runtimeConfig.Protocol,
+			Port:            runtimeConfig.Port,
+			HostPort:        server.Spec.Network.HostPort,
+			Protocol:        runtimeConfig.Protocol,
+			AdditionalPorts: additionalPorts,
 		},
 		Resources: domain.WorkloadResources{
 			CPULimitCores: server.Spec.Resources.CPULimitCores,


### PR DESCRIPTION
## Summary
- add support for additional game workload port mappings
- expose the DST Caves shard on the UDP port following Master
- preserve single-port behavior for other providers

## Validation
- go test ./...
- go vet ./...