### PR TITLE
chore: update DST server image

### DIFF
--- a/apps/api/internal/http/server_handlers_test.go
+++ b/apps/api/internal/http/server_handlers_test.go
@@ -523,7 +523,7 @@ func TestCreateDSTServerUsesDSTRuntimeSpec(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("expected async start to create runtime container")
 	}
-	if spec.Image != "smartcat99999/dst-server:v2026.06.21" {
+	if spec.Image != "smartcat99999/dst-server:v2026.07.17" {
 		t.Fatalf("expected DST image, got %q", spec.Image)
 	}
 	if spec.Port != 10999 || spec.Options.PortProtocol != "udp" {

--- a/apps/api/internal/provider/dst/provider.go
+++ b/apps/api/internal/provider/dst/provider.go
@@ -13,7 +13,7 @@ import (
 
 const DefaultInternalPort = 10999
 
-var versions = []string{"v2026.06.21"}
+var versions = []string{"v2026.07.17", "v2026.06.21"}
 
 type Provider struct {
 	runtime runtimecatalog.RuntimeConfig

--- a/apps/api/internal/provider/dst/provider_test.go
+++ b/apps/api/internal/provider/dst/provider_test.go
@@ -109,7 +109,7 @@ func TestRuntimeOptionsRenderDSTFiles(t *testing.T) {
 	provider := NewProvider()
 	options := runtimeOptions(config)
 
-	if provider.ImageFor("") != "smartcat99999/dst-server:v2026.06.21" {
+	if provider.ImageFor("") != "smartcat99999/dst-server:v2026.07.17" {
 		t.Fatalf("unexpected DST image: %s", provider.ImageFor(""))
 	}
 	if options.PortProtocol != "udp" {

--- a/config/providers.json
+++ b/config/providers.json
@@ -15,7 +15,7 @@
     },
     "dont-starve-together": {
       "imageTemplate": "{registry}/dst-server:{version}",
-      "versions": ["v2026.06.21"]
+      "versions": ["v2026.07.17", "v2026.06.21"]
     },
     "palworld": {
       "imageTemplate": "{registry}/palworld-server:{version}",

--- a/docker/dst/Dockerfile
+++ b/docker/dst/Dockerfile
@@ -4,14 +4,14 @@
 # even though app 343050 supports anonymous installation. Use a digest-pinned,
 # preinstalled upstream image as the binary source so builds stay reproducible
 # and never require a personal Steam account.
-ARG DST_BASE_IMAGE=webhippie/dst@sha256:f4479666ebb55903f2f1e5a94f4c4dcd5fae5d6a7eb896cb6285d1860d789bad
+ARG DST_BASE_IMAGE=webhippie/dst@sha256:798067e88a9120bb5635cec18d125d430bb7e8be26f84f943f2cfee906705891
 FROM ${DST_BASE_IMAGE} AS installer
 
 FROM debian:bookworm-slim
 
 LABEL org.opencontainers.image.title="GamePanel Lite Don't Starve Together"
 LABEL org.opencontainers.image.description="Prebuilt Don't Starve Together dedicated server runtime for GamePanel Lite"
-LABEL org.opencontainers.image.base.name="docker.io/webhippie/dst@sha256:f4479666ebb55903f2f1e5a94f4c4dcd5fae5d6a7eb896cb6285d1860d789bad"
+LABEL org.opencontainers.image.base.name="docker.io/webhippie/dst@sha256:798067e88a9120bb5635cec18d125d430bb7e8be26f84f943f2cfee906705891"
 
 RUN dpkg --add-architecture i386 \
     && apt-get update \

--- a/scripts/build-game-images.sh
+++ b/scripts/build-game-images.sh
@@ -179,7 +179,7 @@ if [[ "$target" == "all" || "$target" == "tmodloader" ]]; then
 fi
 
 if [[ "$target" == "dst" ]]; then
-  build_dst "v2026.06.21"
+  build_dst "v2026.07.17"
 fi
 
 if [[ "$target" == "palworld" ]]; then


### PR DESCRIPTION
## Summary
- pin the current DST upstream image digest
- publish v2026.07.17 while retaining v2026.06.21 for rollback
- update the provider catalog and local build target

## Validation
- verified DST Build ID 24080846
- go test ./...
- go vet ./...
- deployed and verified Master/Caves ready