### PR TITLE
fix: polish resource controls and Palworld defaults

### DIFF
--- a/apps/api/internal/provider/palworld/config.go
+++ b/apps/api/internal/provider/palworld/config.go
@@ -35,7 +35,7 @@ func configSchema() []domain.ProviderConfigField {
 		{Name: "itemCorruptionRate", Label: "食物腐败速度倍率", Type: "number", Required: true, Default: 1, Min: n(0), Max: n(10), Step: n(0.1)},
 		{Name: "equipmentDurabilityRate", Label: "装备耐久消耗倍率", Type: "number", Required: true, Default: 1, Min: n(0), Max: n(10), Step: n(0.1)},
 		{Name: "supplyDropSpan", Label: "陨石与补给间隔（分钟）", Type: "number", Required: true, Default: 180, Min: n(1), Max: n(1440), Step: n(1)},
-		{Name: "deathPenalty", Label: "死亡惩罚", Type: "select", Required: true, Default: "All", Options: []domain.ProviderConfigFieldOption{{Value: "None", Label: "不掉落"}, {Value: "Item", Label: "掉落物品"}, {Value: "ItemAndEquipment", Label: "掉落物品和装备"}, {Value: "All", Label: "掉落全部及队伍帕鲁"}}},
+		{Name: "deathPenalty", Label: "死亡惩罚", Type: "select", Required: true, Default: "None", Options: []domain.ProviderConfigFieldOption{{Value: "None", Label: "不掉落"}, {Value: "Item", Label: "掉落物品"}, {Value: "ItemAndEquipment", Label: "掉落物品和装备"}, {Value: "All", Label: "掉落全部及队伍帕鲁"}}},
 		{Name: "enableInvaderEnemy", Label: "开启入侵事件", Type: "boolean", Default: true},
 		{Name: "enableFastTravel", Label: "开启快速传送", Type: "boolean", Default: true},
 		{Name: "pvp", Label: "开启 PVP", Type: "boolean", Default: false},

--- a/apps/api/internal/provider/palworld/provider.go
+++ b/apps/api/internal/provider/palworld/provider.go
@@ -78,7 +78,7 @@ func (p Provider) ImageFor(version string) string {
 	return p.runtime.WithFallback(runtimeConfig()).ImageFor(version)
 }
 func defaultConfig() Config {
-	return normalizeConfig(Config{EggHatchingTime: 72, ExpRate: 1, CaptureRate: 1, PalSpawnRate: 1, EnemyDropRate: 1, CollectionDropRate: 1, DayTimeSpeedRate: 1, NightTimeSpeedRate: 1, BuildingDeteriorationRate: 1, PlayerDamageAttackRate: 1, PlayerDamageDefenseRate: 1, PalDamageAttackRate: 1, PalDamageDefenseRate: 1, PlayerStaminaRate: 1, PlayerHungerRate: 1, PalStaminaRate: 1, PalHungerRate: 1, CollectionRespawnRate: 1, ItemCorruptionRate: 1, EquipmentDurabilityRate: 1, SupplyDropSpan: 180, BaseCampMaxNum: 128, BaseCampMaxNumInGuild: 4, BaseCampWorkerMaxNum: 15, GuildPlayerMaxNum: 20, DeathPenalty: "All", EnableInvaderEnemy: true, EnableFastTravel: true})
+	return normalizeConfig(Config{EggHatchingTime: 72, ExpRate: 1, CaptureRate: 1, PalSpawnRate: 1, EnemyDropRate: 1, CollectionDropRate: 1, DayTimeSpeedRate: 1, NightTimeSpeedRate: 1, BuildingDeteriorationRate: 1, PlayerDamageAttackRate: 1, PlayerDamageDefenseRate: 1, PalDamageAttackRate: 1, PalDamageDefenseRate: 1, PlayerStaminaRate: 1, PlayerHungerRate: 1, PalStaminaRate: 1, PalHungerRate: 1, CollectionRespawnRate: 1, ItemCorruptionRate: 1, EquipmentDurabilityRate: 1, SupplyDropSpan: 180, BaseCampMaxNum: 128, BaseCampMaxNumInGuild: 4, BaseCampWorkerMaxNum: 15, GuildPlayerMaxNum: 20, DeathPenalty: "None", EnableInvaderEnemy: true, EnableFastTravel: true})
 }
 func (p Provider) DefaultConfigPayload() map[string]any {
 	return payloadFromConfig(defaultConfig())
@@ -321,7 +321,7 @@ func normalizeConfig(config Config) Config {
 		config.GuildPlayerMaxNum = 20
 	}
 	if config.DeathPenalty == "" {
-		config.DeathPenalty = "All"
+		config.DeathPenalty = "None"
 	}
 	config.Port = DefaultInternalPort
 	return config

--- a/apps/api/internal/provider/palworld/provider_test.go
+++ b/apps/api/internal/provider/palworld/provider_test.go
@@ -47,6 +47,29 @@ func TestNormalizeAndValidateConfig(t *testing.T) {
 	}
 }
 
+func TestDefaultDeathPenaltyDoesNotDropItems(t *testing.T) {
+	config := defaultConfig()
+	if config.DeathPenalty != "None" {
+		t.Fatalf("expected panel default death penalty None, got %q", config.DeathPenalty)
+	}
+
+	var schemaDefault any
+	for _, field := range configSchema() {
+		if field.Name == "deathPenalty" {
+			schemaDefault = field.Default
+			break
+		}
+	}
+	if schemaDefault != "None" {
+		t.Fatalf("expected schema death penalty default None, got %#v", schemaDefault)
+	}
+
+	env := strings.Join(runtimeOptions(normalizeConfig(Config{})).Env, "\n")
+	if !strings.Contains(env, "DEATH_PENALTY=None") {
+		t.Fatalf("expected runtime default to disable death drops, got:\n%s", env)
+	}
+}
+
 func TestRuntimeOptionsUsePalworldImageAndUdpPort(t *testing.T) {
 	config := normalizeConfig(Config{
 		ServerName:     "Pal Friends",

--- a/apps/web/components/create-server-wizard.tsx
+++ b/apps/web/components/create-server-wizard.tsx
@@ -1705,7 +1705,7 @@ function RuntimeResourceSection({
         <h3 className="text-sm font-semibold text-slate-100">{t("runtimeResources")}</h3>
         <p className="mt-1 max-w-2xl text-xs leading-5 text-slate-500">{t("resourceLimitsHint")}</p>
       </div>
-      <div className="mt-4 grid gap-3 md:grid-cols-2">
+      <div className="mt-4 grid gap-3">
         <div className="rounded-md border border-panel-line bg-slate-950/45 p-4">
           <ResourceLimitSlider
             formatValue={(value) => formatCpuResourceLimit(value, t("unlimited"), t("cpuUnit"))}

--- a/apps/web/components/resource-limit-slider.tsx
+++ b/apps/web/components/resource-limit-slider.tsx
@@ -26,12 +26,12 @@ export function ResourceLimitSlider({
   return (
     <div className="min-w-0">
       <p className="mb-2 text-sm font-medium text-slate-300">{label}</p>
-      <div className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3">
+      <div className="grid grid-cols-[4.5rem_minmax(0,1fr)_4.5rem] items-center gap-3">
         <span className="text-[11px] tabular-nums text-slate-500">{formatValue(0)}</span>
         <div className="relative min-w-0 pt-7" style={rangeStyle}>
           <output
             className="pointer-events-none absolute top-0 min-w-12 -translate-x-1/2 whitespace-nowrap rounded bg-slate-800 px-2 py-0.5 text-center text-xs font-semibold tabular-nums text-slate-100"
-            style={{ left: `clamp(2rem, ${valuePercent}%, calc(100% - 2rem))` }}
+            style={{ left: `${valuePercent}%` }}
           >
             {formatValue(clampedValue)}
           </output>
@@ -47,7 +47,7 @@ export function ResourceLimitSlider({
             onChange={(event) => onChange(Number(event.target.value))}
           />
         </div>
-        <span className="text-[11px] tabular-nums text-slate-500">{formatValue(max)}</span>
+        <span className="text-right text-[11px] tabular-nums text-slate-500">{formatValue(max)}</span>
       </div>
     </div>
   );

--- a/docs/goals/V1_PROGRESS.md
+++ b/docs/goals/V1_PROGRESS.md
@@ -4,7 +4,7 @@
 
 - Aligned resource slider value badges exactly over their thumbs and fixed endpoint column widths so CPU and memory tracks share identical horizontal geometry.
 - Changed GamePanel Lite's Palworld new-server death-penalty default from the official `All` setting to the friendlier `None` setting across schema defaults, normalization, and runtime environment generation; existing saved servers remain unchanged.
-- Stacked CPU and memory resource controls vertically, and removed redundant per-step tick labels and memory recommendations, keeping only endpoints and the thumb-aligned current value.
+- Stacked CPU and memory resource controls vertically in both server creation and server details, and removed redundant per-step tick labels and memory recommendations, keeping only endpoints and the thumb-aligned current value.
 - Restored the delete-server action to the mobile server-detail overflow menu while retaining the existing destructive confirmation flow.
 - Unified creation and server-detail resource limits around compact sliders with thumb-aligned values, every whole-core CPU marker on common hosts, readable memory capacity markers, and a detected recommended memory ceiling.
 - Collapsed provider boolean settings into single-row label-and-switch controls and replaced per-field reset icons with one advanced-settings-wide restore-defaults action.

--- a/docs/goals/V1_PROGRESS.md
+++ b/docs/goals/V1_PROGRESS.md
@@ -2,6 +2,7 @@
 
 ## 2026-07-19
 
+- Aligned resource slider value badges exactly over their thumbs and fixed endpoint column widths so CPU and memory tracks share identical horizontal geometry.
 - Changed GamePanel Lite's Palworld new-server death-penalty default from the official `All` setting to the friendlier `None` setting across schema defaults, normalization, and runtime environment generation; existing saved servers remain unchanged.
 - Stacked CPU and memory resource controls vertically, and removed redundant per-step tick labels and memory recommendations, keeping only endpoints and the thumb-aligned current value.
 - Restored the delete-server action to the mobile server-detail overflow menu while retaining the existing destructive confirmation flow.

--- a/docs/goals/V1_PROGRESS.md
+++ b/docs/goals/V1_PROGRESS.md
@@ -2,6 +2,7 @@
 
 ## 2026-07-19
 
+- Changed GamePanel Lite's Palworld new-server death-penalty default from the official `All` setting to the friendlier `None` setting across schema defaults, normalization, and runtime environment generation; existing saved servers remain unchanged.
 - Stacked CPU and memory resource controls vertically, and removed redundant per-step tick labels and memory recommendations, keeping only endpoints and the thumb-aligned current value.
 - Restored the delete-server action to the mobile server-detail overflow menu while retaining the existing destructive confirmation flow.
 - Unified creation and server-detail resource limits around compact sliders with thumb-aligned values, every whole-core CPU marker on common hosts, readable memory capacity markers, and a detected recommended memory ceiling.


### PR DESCRIPTION
## What changed

- default new Palworld servers to no item loss on death
- align resource slider value badges and endpoint geometry
- stack CPU and memory resource controls vertically during server creation

## Why

The previous defaults were less friendly for new servers, and the resource controls remained visually crowded or misaligned in parts of the creation flow.

## Impact

New Palworld servers use the friendlier death-penalty default. Existing servers are unchanged. Resource limits now use consistent, readable slider geometry in creation and detail views.

## Validation

- `go test ./...`
- `go vet ./...`
- `pnpm --dir apps/web lint`
- `pnpm --dir apps/web typecheck`
- `pnpm --dir apps/web test -- --run`
- `pnpm --dir apps/web build`
