### PR TITLE
fix: refresh DST mods only on restart

### DIFF
--- a/apps/api/internal/domain/server.go
+++ b/apps/api/internal/domain/server.go
@@ -48,10 +48,11 @@ type ServerNetworkSpec struct {
 }
 
 type ServerRuntimeSpec struct {
-	DataDir string   `json:"dataDir,omitempty"`
-	Image   string   `json:"image,omitempty"`
-	Env     []string `json:"env,omitempty"`
-	Cmd     []string `json:"cmd,omitempty"`
+	DataDir     string   `json:"dataDir,omitempty"`
+	Image       string   `json:"image,omitempty"`
+	Env         []string `json:"env,omitempty"`
+	Cmd         []string `json:"cmd,omitempty"`
+	ModSyncMode string   `json:"modSyncMode,omitempty"`
 }
 
 type ServerSpec struct {

--- a/apps/api/internal/provider/dst/entrypoint_test.go
+++ b/apps/api/internal/provider/dst/entrypoint_test.go
@@ -1,0 +1,144 @@
+package dst
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDSTEntrypointReusesCompleteWorkshopCacheOnStart(t *testing.T) {
+	root, dataDir, script := dstEntrypointFixture(t, true)
+	for _, id := range []string{"111", "222"} {
+		writeTestFile(t, filepath.Join(dataDir, "ugc_mods", "content", "322330", id, "modinfo.lua"), "cached")
+	}
+
+	output, err := runDSTEntrypoint(t, root, dataDir, script, "reuse")
+	if err != nil {
+		t.Fatalf("run entrypoint: %v\n%s", err, output)
+	}
+	if !strings.Contains(output, "Reusing verified GamePanel DST Workshop cache.") {
+		t.Fatalf("expected cache reuse message, got:\n%s", output)
+	}
+	log := readTestFile(t, filepath.Join(dataDir, "fake-server.log"))
+	if strings.Contains(log, "-only_update_server_mods") {
+		t.Fatalf("expected start to skip mod download, got %q", log)
+	}
+}
+
+func TestDSTEntrypointRefreshesAllWorkshopModsOnRestart(t *testing.T) {
+	root, dataDir, script := dstEntrypointFixture(t, true)
+	writeTestFile(t, filepath.Join(dataDir, "ugc_mods", "old-cache"), "old")
+
+	output, err := runDSTEntrypoint(t, root, dataDir, script, "refresh")
+	if err != nil {
+		t.Fatalf("run entrypoint: %v\n%s", err, output)
+	}
+	if !strings.Contains(output, "Refreshed and verified all GamePanel DST server mods.") {
+		t.Fatalf("expected refresh success message, got:\n%s", output)
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, "ugc_mods", "old-cache")); !os.IsNotExist(err) {
+		t.Fatalf("expected old cache to be atomically replaced, stat err=%v", err)
+	}
+	for _, id := range []string{"111", "222"} {
+		if _, err := os.Stat(filepath.Join(dataDir, "ugc_mods", "content", "322330", id, "modinfo.lua")); err != nil {
+			t.Fatalf("expected refreshed mod %s: %v", id, err)
+		}
+	}
+}
+
+func TestDSTEntrypointPreservesOldCacheWhenRefreshIsIncomplete(t *testing.T) {
+	root, dataDir, script := dstEntrypointFixture(t, false)
+	writeTestFile(t, filepath.Join(dataDir, "ugc_mods", "old-cache"), "old")
+
+	output, err := runDSTEntrypoint(t, root, dataDir, script, "refresh")
+	if err == nil {
+		t.Fatalf("expected incomplete refresh to fail, got:\n%s", output)
+	}
+	if !strings.Contains(output, "DST Workshop refresh failed; missing IDs: 111, 222") {
+		t.Fatalf("expected missing mod IDs, got:\n%s", output)
+	}
+	if got := readTestFile(t, filepath.Join(dataDir, "ugc_mods", "old-cache")); got != "old" {
+		t.Fatalf("expected old cache to remain intact, got %q", got)
+	}
+}
+
+func dstEntrypointFixture(t *testing.T, downloaderCreatesMods bool) (string, string, string) {
+	t.Helper()
+	root := t.TempDir()
+	dataDir := filepath.Join(root, "data")
+	clusterDir := filepath.Join(dataDir, "dst", "GamePanelLite")
+	writeTestFile(t, filepath.Join(clusterDir, "cluster_token.txt"), "token")
+	writeTestFile(t, filepath.Join(clusterDir, "cluster.ini"), "[GAMEPLAY]\n")
+	writeTestFile(t, filepath.Join(clusterDir, "dedicated_server_mods_setup.lua"), "ServerModSetup(\"111\")\nServerModSetup(\"222\")\n")
+
+	fake := `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${DST_PERSISTENT_ROOT}/fake-server.log"
+if [[ " $* " == *" -only_update_server_mods "* ]]; then
+  ugc=""
+  while [[ $# -gt 0 ]]; do
+    if [[ "$1" == "-ugc_directory" ]]; then ugc="$2"; break; fi
+    shift
+  done
+  if [[ "${FAKE_DOWNLOAD_MODS:-0}" == "1" ]]; then
+    for id in 111 222; do
+      mkdir -p "${ugc}/content/322330/${id}"
+      printf 'mod' > "${ugc}/content/322330/${id}/modinfo.lua"
+    done
+  fi
+fi
+`
+	writeTestFile(t, filepath.Join(root, "server", "bin64", "dontstarve_dedicated_server_nullrenderer_x64"), fake)
+	if err := os.Chmod(filepath.Join(root, "server", "bin64", "dontstarve_dedicated_server_nullrenderer_x64"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	script, err := filepath.Abs(filepath.Join("..", "..", "..", "..", "..", "docker", "dst", "gamepanel-dst-entrypoint.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(script); err != nil {
+		t.Fatalf("locate entrypoint: %v", err)
+	}
+	if downloaderCreatesMods {
+		t.Setenv("FAKE_DOWNLOAD_MODS", "1")
+	} else {
+		t.Setenv("FAKE_DOWNLOAD_MODS", "0")
+	}
+	return root, dataDir, script
+}
+
+func runDSTEntrypoint(t *testing.T, root, dataDir, script, mode string) (string, error) {
+	t.Helper()
+	cmd := exec.Command("bash", script)
+	cmd.Env = append(os.Environ(),
+		"DST_ROOT_DIR="+root,
+		"DST_PERSISTENT_ROOT="+dataDir,
+		"DST_CONF_DIR=dst",
+		"DST_CLUSTER_NAME=GamePanelLite",
+		"DST_MOD_SYNC_MODE="+mode,
+	)
+	output, err := cmd.CombinedOutput()
+	return string(output), err
+}
+
+func writeTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readTestFile(t *testing.T, path string) string {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(content)
+}

--- a/apps/api/internal/server/reconciler.go
+++ b/apps/api/internal/server/reconciler.go
@@ -123,13 +123,8 @@ func (r *Reconciler) reconcileRunning(ctx context.Context, server domain.GameSer
 			return r.markRunning(server, now), nil
 		}
 	}
-	if needsRecreate && server.Status.RuntimeID != "" {
-		if err := r.removeWorkload(ctx, server.Status.RuntimeID, recorder); err != nil {
-			return r.markFailed(server, now, "RemoveFailed", err.Error()), nil
-		}
-		server.Status.RuntimeID = ""
-	}
-	if server.Status.RuntimeID == "" {
+	var replacementSpec *domain.WorkloadSpec
+	if needsRecreate {
 		spec, err := r.builder.BuildWorkloadSpec(ctx, server)
 		if err != nil {
 			recorder.failed("server.container.prepare.failed", "Build runtime container spec", "", "", err)
@@ -143,14 +138,26 @@ func (r *Reconciler) reconcileRunning(ctx context.Context, server domain.GameSer
 			}
 			recorder.event("server.image.load.succeeded", "Loaded runtime image for server "+server.Name, map[string]any{"image": spec.Image})
 		}
-		recorder.event("server.container.create.started", "Create runtime container for server "+server.Name, map[string]any{"image": spec.Image})
-		runtimeID, err := r.runtime.Create(ctx, spec)
+		replacementSpec = &spec
+	}
+	if needsRecreate && server.Status.RuntimeID != "" {
+		if err := r.removeWorkload(ctx, server.Status.RuntimeID, recorder); err != nil {
+			return r.markFailed(server, now, "RemoveFailed", err.Error()), nil
+		}
+		server.Status.RuntimeID = ""
+	}
+	if server.Status.RuntimeID == "" {
+		if replacementSpec == nil {
+			return r.markFailed(server, now, "BuildSpecFailed", "replacement workload spec is unavailable"), nil
+		}
+		recorder.event("server.container.create.started", "Create runtime container for server "+server.Name, map[string]any{"image": replacementSpec.Image})
+		runtimeID, err := r.runtime.Create(ctx, *replacementSpec)
 		if err != nil {
-			recorder.failed("server.container.create.failed", "Create runtime container", "", spec.Image, err)
+			recorder.failed("server.container.create.failed", "Create runtime container", "", replacementSpec.Image, err)
 			return r.markFailed(server, now, "CreateFailed", err.Error()), nil
 		}
 		server.Status.RuntimeID = runtimeID
-		recorder.event("server.container.create.succeeded", "Created runtime container for server "+server.Name, map[string]any{"image": spec.Image, "runtimeId": runtimeID})
+		recorder.event("server.container.create.succeeded", "Created runtime container for server "+server.Name, map[string]any{"image": replacementSpec.Image, "runtimeId": runtimeID})
 	}
 	recorder.event("server.container.start.started", "Start runtime container for server "+server.Name, map[string]any{"runtimeId": server.Status.RuntimeID})
 	if err := r.runtime.Start(ctx, server.Status.RuntimeID); err != nil {
@@ -245,6 +252,7 @@ func (r *Reconciler) removeWorkload(ctx context.Context, runtimeID string, recor
 }
 
 func (r *Reconciler) markRunning(server domain.GameServer, now time.Time) domain.GameServer {
+	server.Spec.Runtime.ModSyncMode = ""
 	server.Status.ActualState = domain.ActualRunning
 	server.Status.ObservedGeneration = server.Spec.Generation
 	server.Status.AppliedGeneration = server.Spec.Generation

--- a/apps/api/internal/server/reconciler_test.go
+++ b/apps/api/internal/server/reconciler_test.go
@@ -173,6 +173,62 @@ func TestReconcileRunningCreatesAndStartsWorkload(t *testing.T) {
 	}
 }
 
+func TestReconcileRunningPreparesReplacementBeforeStoppingCurrentWorkload(t *testing.T) {
+	builder := &fakeBuilder{err: errors.New("invalid desired mod")}
+	runtime := newFakeRuntime()
+	runtime.states["runtime-srv-safe"] = domain.ActualRunning
+	reconciler := NewRuntimeReconciler(builder, runtime)
+	server := domain.GameServer{
+		ID:   "srv-safe",
+		Name: "Safe Restart",
+		Spec: domain.ServerSpec{Generation: 2, DesiredState: domain.DesiredRunning},
+		Status: domain.ServerRuntimeStatus{
+			Phase:             domain.PhasePending,
+			ActualState:       domain.ActualRunning,
+			RuntimeID:         "runtime-srv-safe",
+			AppliedGeneration: 1,
+		},
+	}
+
+	updated, err := reconciler.Reconcile(context.Background(), server)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if updated.Status.Phase != domain.PhaseFailed || updated.Status.LastError != "invalid desired mod" {
+		t.Fatalf("expected failed replacement preparation, got %+v", updated.Status)
+	}
+	if runtime.stopped != 0 || runtime.removed != 0 {
+		t.Fatalf("expected current workload to remain untouched, stopped=%d removed=%d", runtime.stopped, runtime.removed)
+	}
+	if runtime.states["runtime-srv-safe"] != domain.ActualRunning {
+		t.Fatal("expected current workload to remain running")
+	}
+}
+
+func TestReconcileRunningClearsOneShotModSyncMode(t *testing.T) {
+	builder := &fakeBuilder{}
+	runtime := newFakeRuntime()
+	reconciler := NewRuntimeReconciler(builder, runtime)
+	server := domain.GameServer{
+		ID:   "srv-refresh",
+		Name: "Refresh Once",
+		Spec: domain.ServerSpec{
+			Generation:   1,
+			DesiredState: domain.DesiredRunning,
+			Runtime:      domain.ServerRuntimeSpec{ModSyncMode: "refresh"},
+		},
+		Status: domain.ServerRuntimeStatus{Phase: domain.PhasePending, ActualState: domain.ActualMissing},
+	}
+
+	updated, err := reconciler.Reconcile(context.Background(), server)
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if updated.Spec.Runtime.ModSyncMode != "" {
+		t.Fatalf("expected one-shot mod sync mode to clear, got %q", updated.Spec.Runtime.ModSyncMode)
+	}
+}
+
 func TestReconcileRunningRecordsLifecycleEvents(t *testing.T) {
 	builder := &fakeBuilder{}
 	runtime := newFakeRuntime()

--- a/apps/api/internal/server/service.go
+++ b/apps/api/internal/server/service.go
@@ -58,25 +58,26 @@ func (s *Service) Create(ctx context.Context, cmd CreateCommand) (domain.GameSer
 }
 
 func (s *Service) RequestStart(ctx context.Context, id string) (domain.GameServer, error) {
-	return s.updateIntent(ctx, id, domain.DesiredRunning, markPending)
+	return s.updateIntent(ctx, id, domain.DesiredRunning, "reuse", markPending)
 }
 
 func (s *Service) RequestStop(ctx context.Context, id string) (domain.GameServer, error) {
-	return s.updateIntent(ctx, id, domain.DesiredStopped, markPending)
+	return s.updateIntent(ctx, id, domain.DesiredStopped, "", markPending)
 }
 
 func (s *Service) RequestRestart(ctx context.Context, id string) (domain.GameServer, error) {
-	return s.updateIntent(ctx, id, domain.DesiredRunning, markPending)
+	return s.updateIntent(ctx, id, domain.DesiredRunning, "refresh", markPending)
 }
 
 func (s *Service) RequestDelete(ctx context.Context, id string) (domain.GameServer, error) {
-	return s.updateIntent(ctx, id, domain.DesiredDeleted, markDeleting)
+	return s.updateIntent(ctx, id, domain.DesiredDeleted, "", markDeleting)
 }
 
 func (s *Service) updateIntent(
 	ctx context.Context,
 	id string,
 	desired domain.ServerDesiredState,
+	modSyncMode string,
 	updateStatus func(*domain.ServerRuntimeStatus, time.Time),
 ) (domain.GameServer, error) {
 	server, err := s.store.GetGameServer(ctx, id)
@@ -85,6 +86,9 @@ func (s *Service) updateIntent(
 	}
 	now := s.clock()
 	server.Spec.DesiredState = desired
+	if server.ProviderKey == domain.ProviderDST {
+		server.Spec.Runtime.ModSyncMode = modSyncMode
+	}
 	bumpSpecGeneration(&server.Spec)
 	updateStatus(&server.Status, now)
 	server.UpdatedAt = now

--- a/apps/api/internal/server/service_test.go
+++ b/apps/api/internal/server/service_test.go
@@ -95,3 +95,40 @@ func TestServiceRequestsBumpGeneration(t *testing.T) {
 		t.Fatalf("expected generation 3, got %d", deleting.Spec.Generation)
 	}
 }
+
+func TestDSTStartReusesModsAndRestartRefreshesMods(t *testing.T) {
+	store := newMemoryStore()
+	service := NewService(store)
+	server, err := service.Create(context.Background(), CreateCommand{
+		Name:        "DST Friends",
+		GameKey:     domain.GameDST,
+		ProviderKey: domain.ProviderDST,
+	})
+	if err != nil {
+		t.Fatalf("create server: %v", err)
+	}
+
+	started, err := service.RequestStart(context.Background(), server.ID)
+	if err != nil {
+		t.Fatalf("request start: %v", err)
+	}
+	if started.Spec.Runtime.ModSyncMode != "reuse" {
+		t.Fatalf("expected start to reuse DST mod cache, got %q", started.Spec.Runtime.ModSyncMode)
+	}
+
+	restarted, err := service.RequestRestart(context.Background(), server.ID)
+	if err != nil {
+		t.Fatalf("request restart: %v", err)
+	}
+	if restarted.Spec.Runtime.ModSyncMode != "refresh" {
+		t.Fatalf("expected restart to refresh DST mod cache, got %q", restarted.Spec.Runtime.ModSyncMode)
+	}
+
+	stopped, err := service.RequestStop(context.Background(), server.ID)
+	if err != nil {
+		t.Fatalf("request stop: %v", err)
+	}
+	if stopped.Spec.Runtime.ModSyncMode != "" {
+		t.Fatalf("expected stop to clear DST mod sync mode, got %q", stopped.Spec.Runtime.ModSyncMode)
+	}
+}

--- a/apps/api/internal/server/workload.go
+++ b/apps/api/internal/server/workload.go
@@ -84,12 +84,21 @@ func (b *ProviderWorkloadBuilder) BuildWorkloadSpec(ctx context.Context, server 
 		},
 		DataDir: server.Spec.Runtime.DataDir,
 		Options: domain.WorkloadOptions{
-			Env:        append([]string{}, runtimeConfig.Options.Env...),
+			Env:        runtimeEnvironment(runtimeConfig.Options.Env, server),
 			Cmd:        append([]string{}, runtimeConfig.Options.Cmd...),
 			Files:      files,
 			DataMounts: append([]string{}, runtimeConfig.Options.DataMounts...),
 		},
 	}, nil
+}
+
+func runtimeEnvironment(providerEnv []string, server domain.GameServer) []string {
+	env := append([]string{}, providerEnv...)
+	env = append(env, server.Spec.Runtime.Env...)
+	if server.ProviderKey == domain.ProviderDST && server.Spec.Runtime.ModSyncMode != "" {
+		env = append(env, "DST_MOD_SYNC_MODE="+server.Spec.Runtime.ModSyncMode)
+	}
+	return env
 }
 
 func runtimeConfigForResource(gameProvider provider.GameProvider, server domain.GameServer) (domain.ProviderRuntimeConfig, error) {

--- a/apps/api/internal/server/workload_test.go
+++ b/apps/api/internal/server/workload_test.go
@@ -65,6 +65,40 @@ func TestProviderWorkloadBuilderUsesProviderRuntimeContract(t *testing.T) {
 	}
 }
 
+func TestProviderWorkloadBuilderPassesDSTModSyncMode(t *testing.T) {
+	registry := provider.NewRegistry(dst.NewProvider(runtimecatalog.Catalog{}))
+	builder := NewProviderWorkloadBuilder(registry)
+	server := domain.GameServer{
+		ID:          "dst-sync",
+		Name:        "DST Sync",
+		GameKey:     domain.GameDST,
+		ProviderKey: domain.ProviderDST,
+		Spec: domain.ServerSpec{
+			Version: "latest",
+			Config: map[string]any{
+				"identity": map[string]any{
+					"serverName":   "DST Sync",
+					"clusterName":  "GamePanelLite",
+					"clusterToken": "token",
+				},
+				"gameplay": map[string]any{"maxPlayers": float64(6)},
+				"world":    map[string]any{"preset": "forest_default"},
+				"port":     float64(10999),
+			},
+			Network: domain.ServerNetworkSpec{Port: 10999, HostPort: 10999},
+			Runtime: domain.ServerRuntimeSpec{DataDir: t.TempDir(), ModSyncMode: "refresh"},
+		},
+	}
+
+	spec, err := builder.BuildWorkloadSpec(context.Background(), server)
+	if err != nil {
+		t.Fatalf("build workload spec: %v", err)
+	}
+	if !containsEnv(spec.Options.Env, "DST_MOD_SYNC_MODE=refresh") {
+		t.Fatalf("expected DST refresh mode in workload env, got %+v", spec.Options.Env)
+	}
+}
+
 func TestProviderWorkloadBuilderPlansDesiredModsFromServerSpec(t *testing.T) {
 	root := t.TempDir()
 	db, err := store.Open(filepath.Join(root, "gamepanel.db"))

--- a/docker/dst/gamepanel-dst-entrypoint.sh
+++ b/docker/dst/gamepanel-dst-entrypoint.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="/home/container"
+ROOT_DIR="${DST_ROOT_DIR:-/home/container}"
 SERVER_DIR="${ROOT_DIR}/server"
 PERSISTENT_ROOT="${DST_PERSISTENT_ROOT:-/data}"
 CONF_DIR="${DST_CONF_DIR:-dst}"
 CLUSTER_NAME="${DST_CLUSTER_NAME:-GamePanelLite}"
 CLUSTER_DIR="${PERSISTENT_ROOT}/${CONF_DIR}/${CLUSTER_NAME}"
 UGC_DIR="${DST_UGC_DIRECTORY:-${PERSISTENT_ROOT}/ugc_mods}"
+MOD_SYNC_MODE="${DST_MOD_SYNC_MODE:-reuse}"
 
 server_bin() {
   if [[ -x "${SERVER_DIR}/bin64/dontstarve_dedicated_server_nullrenderer_x64" ]]; then
@@ -47,6 +48,99 @@ ensure_cluster_layout() {
   fi
 }
 
+configured_workshop_ids() {
+  local setup_file="${SERVER_DIR}/mods/dedicated_server_mods_setup.lua"
+  [[ -f "${setup_file}" ]] || return 0
+  sed -n 's/^[[:space:]]*ServerModSetup("\([0-9][0-9]*\)").*/\1/p' "${setup_file}"
+}
+
+mod_is_cached() {
+  local ugc_dir="$1"
+  local workshop_id="$2"
+  [[ -f "${ugc_dir}/content/322330/${workshop_id}/modinfo.lua" ]] \
+    || [[ -f "${SERVER_DIR}/mods/workshop-${workshop_id}/modinfo.lua" ]]
+}
+
+missing_workshop_ids() {
+  local ugc_dir="$1"
+  local workshop_id
+  while IFS= read -r workshop_id; do
+    [[ -n "${workshop_id}" ]] || continue
+    if ! mod_is_cached "${ugc_dir}" "${workshop_id}"; then
+      printf '%s\n' "${workshop_id}"
+    fi
+  done < <(configured_workshop_ids)
+}
+
+download_server_mods() {
+  local ugc_dir="$1"
+  local bin
+  bin="$(server_bin)"
+  mkdir -p "${ugc_dir}" "${ugc_dir}/content/322330" "${ugc_dir}/downloads" "${ugc_dir}/temp"
+  cd "${SERVER_DIR}/bin64" 2>/dev/null || cd "${SERVER_DIR}/bin"
+  "${bin}" \
+    -only_update_server_mods \
+    -persistent_storage_root "${PERSISTENT_ROOT}" \
+    -conf_dir "${CONF_DIR}" \
+    -cluster "${CLUSTER_NAME}" \
+    -shard "Master" \
+    -ugc_directory "${ugc_dir}"
+}
+
+sync_server_mods() {
+  local configured_count
+  configured_count="$(configured_workshop_ids | sed '/^$/d' | wc -l | tr -d ' ')"
+  if [[ "${configured_count}" == "0" ]]; then
+    echo "No GamePanel DST server mods configured."
+    return 0
+  fi
+
+  if [[ "${MOD_SYNC_MODE}" == "refresh" ]]; then
+    local refresh_dir="${UGC_DIR}.refresh"
+    local previous_dir="${UGC_DIR}.previous"
+    rm -rf "${refresh_dir}"
+    echo "Refreshing all ${configured_count} GamePanel DST server mods..."
+    if ! download_server_mods "${refresh_dir}"; then
+      echo "DST Workshop refresh failed; keeping the previous cache." >&2
+      rm -rf "${refresh_dir}"
+      exit 1
+    fi
+    local missing
+    missing="$(missing_workshop_ids "${refresh_dir}")"
+    if [[ -n "${missing}" ]]; then
+      echo "DST Workshop refresh failed; missing IDs: ${missing//$'\n'/, }" >&2
+      rm -rf "${refresh_dir}"
+      exit 1
+    fi
+    rm -rf "${previous_dir}"
+    if [[ -d "${UGC_DIR}" ]]; then
+      mv "${UGC_DIR}" "${previous_dir}"
+    fi
+    mv "${refresh_dir}" "${UGC_DIR}"
+    rm -rf "${previous_dir}"
+    echo "Refreshed and verified all GamePanel DST server mods."
+    return 0
+  fi
+
+  local missing
+  missing="$(missing_workshop_ids "${UGC_DIR}")"
+  if [[ -z "${missing}" ]]; then
+    echo "Reusing verified GamePanel DST Workshop cache."
+    return 0
+  fi
+  echo "Completing missing GamePanel DST Workshop cache: ${missing//$'\n'/, }"
+  if ! download_server_mods "${UGC_DIR}"; then
+    echo "DST Workshop cache completion failed." >&2
+    exit 1
+  fi
+  missing="$(missing_workshop_ids "${UGC_DIR}")"
+  if [[ -n "${missing}" ]]; then
+    echo "DST Workshop cache is incomplete; missing IDs: ${missing//$'\n'/, }" >&2
+    exit 1
+  fi
+  echo "GamePanel DST Workshop cache is complete."
+}
+
 start_shard() {
   local shard="$1"
   local bin
@@ -71,6 +165,7 @@ terminate_children() {
 }
 
 ensure_cluster_layout
+sync_server_mods
 trap terminate_children TERM INT
 
 if [[ -f "${CLUSTER_DIR}/Caves/server.ini" ]]; then

--- a/docs/goals/V1_PROGRESS.md
+++ b/docs/goals/V1_PROGRESS.md
@@ -2,6 +2,7 @@
 
 ## 2026-07-19
 
+- Separated DST mod synchronization by explicit lifecycle action: Start reuses the verified persistent Workshop cache and downloads only missing entries, while Restart refreshes every configured server mod through a validated staging directory and atomically replaces the live cache only after a complete download.
 - Blocked DST client-only and unclassified Workshop mods from entering the server mod library or server installer in the frontend, while preserving raw Workshop tags in discovery and separating server-only from all-clients-required labeling without changing backend behavior.
 - Prevented configuration and mod edits from implicitly restarting or starting game servers; saved revisions now wait for an explicit restart/start while preserving the current lifecycle state.
 - Aligned resource slider value badges exactly over their thumbs and fixed endpoint column widths so CPU and memory tracks share identical horizontal geometry.


### PR DESCRIPTION
## Summary
- reuse verified persistent DST Workshop cache on explicit start and download only missing mods
- force a complete staged Workshop refresh on explicit restart
- preserve the previous cache when refresh or validation fails
- prepare replacement runtime specs before stopping a running server

## Checks
- GOCACHE=/tmp/gamepanel-go-build go test ./...
- GOCACHE=/tmp/gamepanel-go-build go vet ./...
- pnpm --dir apps/web lint
- pnpm --dir apps/web typecheck
- pnpm --dir apps/web build
- bash -n docker/dst/gamepanel-dst-entrypoint.sh
- git diff --check