### PR TITLE
fix: repair DST cave world defaults

### DIFF
--- a/apps/api/internal/provider/dst/config.go
+++ b/apps/api/internal/provider/dst/config.go
@@ -78,12 +78,24 @@ func worldOptionFields(prefix string, world string) []domain.ProviderConfigField
 			Name:    prefix + ".overrides." + item.Key,
 			Label:   item.Label,
 			Type:    "select",
-			Default: item.Default,
+			Default: defaultForWorld(item, world),
 			Options: options,
 			Group:   strings.Join([]string{"dst", prefix, item.Category, item.Group}, "."),
 		})
 	}
 	return fields
+}
+
+func defaultForWorld(item dstWorldOption, world string) string {
+	if world == "cave" {
+		switch item.Key {
+		case "task_set":
+			return "cave_default"
+		case "start_location":
+			return "caves"
+		}
+	}
+	return item.Default
 }
 
 func valuesForWorld(item dstWorldOption, world string) []string {

--- a/apps/api/internal/provider/dst/provider.go
+++ b/apps/api/internal/provider/dst/provider.go
@@ -338,6 +338,15 @@ func normalizeConfig(config Config) Config {
 			config.Caves.Preset = "cave_default"
 		}
 		config.Caves.Overrides = cleanOverrides(config.Caves.Overrides)
+		// Older schemas exposed forest defaults for these cave-only options.
+		// Normalize persisted values so enabling caves repairs the legacy payload
+		// instead of rejecting it during runtime preparation.
+		if config.Caves.Overrides["task_set"] == "default" {
+			config.Caves.Overrides["task_set"] = "cave_default"
+		}
+		if config.Caves.Overrides["start_location"] == "default" {
+			config.Caves.Overrides["start_location"] = "caves"
+		}
 		if !config.Caves.Enabled {
 			config.Caves = nil
 		}

--- a/apps/api/internal/provider/dst/provider_test.go
+++ b/apps/api/internal/provider/dst/provider_test.go
@@ -134,6 +134,43 @@ func TestKnownWorldOverrideRejectsUnsupportedValue(t *testing.T) {
 	}
 }
 
+func TestCaveSchemaUsesCaveSpecificWorldGenerationDefaults(t *testing.T) {
+	defaults := map[string]any{}
+	for _, field := range configSchema() {
+		if field.Name == "caves.overrides.task_set" || field.Name == "caves.overrides.start_location" {
+			defaults[field.Name] = field.Default
+		}
+	}
+	if defaults["caves.overrides.task_set"] != "cave_default" {
+		t.Fatalf("expected cave task set default, got %v", defaults["caves.overrides.task_set"])
+	}
+	if defaults["caves.overrides.start_location"] != "caves" {
+		t.Fatalf("expected cave start location default, got %v", defaults["caves.overrides.start_location"])
+	}
+}
+
+func TestLegacyCaveWorldGenerationDefaultsAreNormalized(t *testing.T) {
+	config := configFromPayload(map[string]any{
+		"identity": map[string]any{"serverName": "DST", "clusterName": "Cluster", "clusterToken": "token"},
+		"caves": map[string]any{
+			"enabled": true,
+			"overrides": map[string]any{
+				"task_set":       "default",
+				"start_location": "default",
+			},
+		},
+	}, defaultConfig())
+	if got := config.Caves.Overrides["task_set"]; got != "cave_default" {
+		t.Fatalf("expected legacy cave task set to normalize, got %q", got)
+	}
+	if got := config.Caves.Overrides["start_location"]; got != "caves" {
+		t.Fatalf("expected legacy cave start location to normalize, got %q", got)
+	}
+	if err := validateConfig(config); err != nil {
+		t.Fatalf("expected normalized cave config to validate: %v", err)
+	}
+}
+
 func TestNormalizeAndValidateConfig(t *testing.T) {
 	config := normalizeConfig(Config{
 		Identity: DSTIdentityConfig{ServerName: "DST Friends", ClusterName: "Cluster", ClusterToken: "klei-token"},

--- a/apps/web/lib/provider-config.test.ts
+++ b/apps/web/lib/provider-config.test.ts
@@ -134,6 +134,27 @@ describe("provider config helpers", () => {
     });
   });
 
+  it("repairs stored select values that are no longer valid for the schema", () => {
+    const caveProvider: ProviderCatalog = {
+      ...provider,
+      key: "dont-starve-together",
+      configSchema: [
+        {
+          name: "caves.overrides.task_set",
+          label: "Biomes",
+          type: "select",
+          required: false,
+          default: "cave_default",
+          options: [{ value: "cave_default", label: "Default caves" }]
+        }
+      ]
+    };
+
+    expect(createDefaultProviderConfigPayload(caveProvider, {
+      caves: { overrides: { task_set: "default" } }
+    })).toEqual({ caves: { overrides: { task_set: "cave_default" } } });
+  });
+
   it("separates advanced DST and Palworld settings from their basic fields", () => {
     const dstRule: ProviderConfigField = { name: "world.overrides.grass", label: "Grass", type: "select", required: false, default: "default", group: "dst.world.worldsettings.resources" };
     const palRate: ProviderConfigField = { name: "expRate", label: "EXP", type: "number", required: true, default: 1, group: "世界倍率" };

--- a/apps/web/lib/provider-config.ts
+++ b/apps/web/lib/provider-config.ts
@@ -10,7 +10,15 @@ export function createDefaultProviderConfigPayload(
   for (const field of provider?.configSchema ?? []) {
     setProviderConfigValue(payload, field.name, defaultProviderFieldValue(field));
   }
-  return deepMergeProviderPayload(payload, overrides);
+  const merged = deepMergeProviderPayload(payload, overrides);
+  for (const field of provider?.configSchema ?? []) {
+    if (field.type !== "select" || !field.options?.length) continue;
+    const current = String(providerConfigValue(merged, field.name) ?? "");
+    if (!field.options.some((option) => option.value === current)) {
+      setProviderConfigValue(merged, field.name, defaultProviderFieldValue(field));
+    }
+  }
+  return merged;
 }
 
 export function updateProviderConfigPayload(

--- a/docs/goals/V1_PROGRESS.md
+++ b/docs/goals/V1_PROGRESS.md
@@ -2,6 +2,7 @@
 
 ## 2026-07-19
 
+- Fixed cave shard creation by publishing cave-specific defaults for biome and spawn-area generation settings and transparently repairing legacy payloads that stored their forest-only `default` values.
 - Separated DST mod synchronization by explicit lifecycle action: Start reuses the verified persistent Workshop cache and downloads only missing entries, while Restart refreshes every configured server mod through a validated staging directory and atomically replaces the live cache only after a complete download.
 - Blocked DST client-only and unclassified Workshop mods from entering the server mod library or server installer in the frontend, while preserving raw Workshop tags in discovery and separating server-only from all-clients-required labeling without changing backend behavior.
 - Prevented configuration and mod edits from implicitly restarting or starting game servers; saved revisions now wait for an explicit restart/start while preserving the current lifecycle state.


### PR DESCRIPTION
## Summary
- use cave-specific defaults for task_set and start_location
- normalize legacy cave payload values before validation
- repair invalid stored select values in the frontend editor

## Checks
- GOCACHE=/tmp/gamepanel-go-build go test ./...
- GOCACHE=/tmp/gamepanel-go-build go vet ./...
- pnpm --dir apps/web test -- --run lib/provider-config.test.ts
- pnpm --dir apps/web lint
- pnpm --dir apps/web typecheck
- pnpm --dir apps/web build
- git diff --check