### PR TITLE
fix: remove deprecated DST runtime options

### DIFF
--- a/apps/api/internal/provider/dst/entrypoint_test.go
+++ b/apps/api/internal/provider/dst/entrypoint_test.go
@@ -25,6 +25,9 @@ func TestDSTEntrypointReusesCompleteWorkshopCacheOnStart(t *testing.T) {
 	if strings.Contains(log, "-only_update_server_mods") {
 		t.Fatalf("expected start to skip mod download, got %q", log)
 	}
+	if strings.Contains(log, "-console") {
+		t.Fatalf("expected shard startup to omit deprecated -console, got %q", log)
+	}
 }
 
 func TestDSTEntrypointRefreshesAllWorkshopModsOnRestart(t *testing.T) {

--- a/apps/api/internal/provider/dst/provider.go
+++ b/apps/api/internal/provider/dst/provider.go
@@ -474,7 +474,7 @@ func renderClusterINI(config Config) string {
 		"cluster_description = " + config.Identity.Description,
 		"cluster_password = " + config.Identity.Password,
 		"lan_only_cluster = " + boolINI(lanOnly),
-		"offline_server = " + boolINI(offline),
+		"offline_cluster = " + boolINI(offline),
 		"",
 		"[MISC]",
 		"console_enabled = " + boolINI(config.Gameplay.ConsoleEnabled),

--- a/apps/api/internal/provider/dst/provider_test.go
+++ b/apps/api/internal/provider/dst/provider_test.go
@@ -218,10 +218,14 @@ func TestRuntimeOptionsRenderDSTFiles(t *testing.T) {
 		"cluster_password = join-secret",
 		"max_players = 5",
 		"game_mode = survival",
+		"offline_cluster = false",
 	} {
 		if !strings.Contains(cluster, expected) {
 			t.Fatalf("expected cluster.ini to contain %q, got:\n%s", expected, cluster)
 		}
+	}
+	if strings.Contains(cluster, "offline_server") {
+		t.Fatalf("cluster.ini must not use deprecated offline_server:\n%s", cluster)
 	}
 	if got := options.Files["dst/Cluster/cluster_token.txt"]; got != "klei-token\n" {
 		t.Fatalf("expected server token file, got %q", got)

--- a/docker/dst/gamepanel-dst-entrypoint.sh
+++ b/docker/dst/gamepanel-dst-entrypoint.sh
@@ -151,8 +151,7 @@ start_shard() {
     -conf_dir "${CONF_DIR}" \
     -cluster "${CLUSTER_NAME}" \
     -shard "${shard}" \
-    -ugc_directory "${UGC_DIR}" \
-    -console
+    -ugc_directory "${UGC_DIR}"
 }
 
 terminate_children() {

--- a/docs/goals/V1_PROGRESS.md
+++ b/docs/goals/V1_PROGRESS.md
@@ -2,6 +2,7 @@
 
 ## 2026-07-19
 
+- Removed deprecated DST `-console` and `offline_server` usage while retaining console control through the supported cluster setting.
 - Fixed cave shard creation by publishing cave-specific defaults for biome and spawn-area generation settings and transparently repairing legacy payloads that stored their forest-only `default` values.
 - Separated DST mod synchronization by explicit lifecycle action: Start reuses the verified persistent Workshop cache and downloads only missing entries, while Restart refreshes every configured server mod through a validated staging directory and atomically replaces the live cache only after a complete download.
 - Blocked DST client-only and unclassified Workshop mods from entering the server mod library or server installer in the frontend, while preserving raw Workshop tags in discovery and separating server-only from all-clients-required labeling without changing backend behavior.


### PR DESCRIPTION
## Summary
- use offline_cluster instead of deprecated offline_server
- stop passing deprecated -console to DST shards
- keep console behavior through cluster.ini

## Checks
- GOCACHE=/tmp/gamepanel-go-build go test ./...
- GOCACHE=/tmp/gamepanel-go-build go vet ./...
- pnpm --dir apps/web lint
- pnpm --dir apps/web typecheck
- bash -n docker/dst/gamepanel-dst-entrypoint.sh
- git diff --check