### PR TITLE
fix: support legacy DST Workshop mods

### DIFF
--- a/apps/api/internal/provider/dst/entrypoint_test.go
+++ b/apps/api/internal/provider/dst/entrypoint_test.go
@@ -1,6 +1,7 @@
 package dst
 
 import (
+	"archive/zip"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -27,6 +28,9 @@ func TestDSTEntrypointReusesCompleteWorkshopCacheOnStart(t *testing.T) {
 	}
 	if strings.Contains(log, "-console") {
 		t.Fatalf("expected shard startup to omit deprecated -console, got %q", log)
+	}
+	if !strings.Contains(log, "-skip_update_server_mods") {
+		t.Fatalf("expected shard startup to skip duplicate Workshop updates, got %q", log)
 	}
 }
 
@@ -64,6 +68,61 @@ func TestDSTEntrypointPreservesOldCacheWhenRefreshIsIncomplete(t *testing.T) {
 	}
 	if got := readTestFile(t, filepath.Join(dataDir, "ugc_mods", "old-cache")); got != "old" {
 		t.Fatalf("expected old cache to remain intact, got %q", got)
+	}
+}
+
+func TestDSTEntrypointDownloadsAndLinksLegacyWorkshopMod(t *testing.T) {
+	root, dataDir, script := dstEntrypointFixture(t, false)
+	clusterDir := filepath.Join(dataDir, "dst", "GamePanelLite")
+	writeTestFile(t, filepath.Join(clusterDir, "dedicated_server_mods_setup.lua"), "ServerModSetup(\"111\")\n")
+
+	archive := filepath.Join(root, "legacy-mod.zip")
+	writeTestZip(t, archive, map[string]string{
+		"modinfo.lua":                "name = \"Legacy Test\"\n",
+		"modmain.lua":                "return nil\n",
+		"scripts\\components\\x.lua": "return nil\n",
+	})
+	binDir := filepath.Join(root, "fake-bin")
+	fakeCurl := `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$*" == *"GetPublishedFileDetails"* ]]; then
+  printf '{"response":{"result":1,"publishedfiledetails":[{"result":1,"file_url":"file://%s"}]}}' "${FAKE_LEGACY_ARCHIVE}"
+  exit 0
+fi
+out=""
+url=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o) out="$2"; shift 2 ;;
+    file://*) url="$1"; shift ;;
+    *) shift ;;
+  esac
+done
+cp "${url#file://}" "${out}"
+`
+	writeTestFile(t, filepath.Join(binDir, "curl"), fakeCurl)
+	if err := os.Chmod(filepath.Join(binDir, "curl"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("FAKE_LEGACY_ARCHIVE", archive)
+	t.Setenv("DST_LEGACY_WORKSHOP_FALLBACK", "1")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	output, err := runDSTEntrypoint(t, root, dataDir, script, "refresh")
+	if err != nil {
+		t.Fatalf("run entrypoint: %v\n%s", err, output)
+	}
+	legacyDir := filepath.Join(dataDir, "ugc_mods", "legacy", "workshop-111")
+	if _, err := os.Stat(filepath.Join(legacyDir, "modinfo.lua")); err != nil {
+		t.Fatalf("expected persisted legacy mod: %v\n%s", err, output)
+	}
+	link := filepath.Join(root, "server", "mods", "workshop-111")
+	if target, err := os.Readlink(link); err != nil || target != legacyDir {
+		t.Fatalf("expected legacy runtime link to %q, got target=%q err=%v", legacyDir, target, err)
+	}
+	log := readTestFile(t, filepath.Join(dataDir, "fake-server.log"))
+	if strings.Contains(log, "-only_update_server_mods") {
+		t.Fatalf("expected legacy-only refresh to bypass native downloader, got %q", log)
 	}
 }
 
@@ -110,6 +169,7 @@ fi
 	} else {
 		t.Setenv("FAKE_DOWNLOAD_MODS", "0")
 	}
+	t.Setenv("DST_LEGACY_WORKSHOP_FALLBACK", "0")
 	return root, dataDir, script
 }
 
@@ -144,4 +204,28 @@ func readTestFile(t *testing.T, path string) string {
 		t.Fatal(err)
 	}
 	return string(content)
+}
+
+func writeTestZip(t *testing.T, path string, files map[string]string) {
+	t.Helper()
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writer := zip.NewWriter(file)
+	for name, content := range files {
+		entry, err := writer.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := entry.Write([]byte(content)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/docker/dst/Dockerfile
+++ b/docker/dst/Dockerfile
@@ -15,7 +15,7 @@ LABEL org.opencontainers.image.base.name="docker.io/webhippie/dst@sha256:798067e
 
 RUN dpkg --add-architecture i386 \
     && apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates lib32gcc-s1 libcurl4 libcurl4:i386 libcurl3-gnutls libcurl3-gnutls:i386 libstdc++6 libstdc++6:i386 \
+    && apt-get install -y --no-install-recommends ca-certificates curl lib32gcc-s1 libcurl4 libcurl4:i386 libcurl3-gnutls libcurl3-gnutls:i386 libstdc++6 libstdc++6:i386 unzip \
     && rm -rf /var/lib/apt/lists/* \
     && useradd -m -d /home/container -s /bin/bash container \
     && mkdir -p /home/container/server /data \

--- a/docker/dst/gamepanel-dst-entrypoint.sh
+++ b/docker/dst/gamepanel-dst-entrypoint.sh
@@ -9,6 +9,8 @@ CLUSTER_NAME="${DST_CLUSTER_NAME:-GamePanelLite}"
 CLUSTER_DIR="${PERSISTENT_ROOT}/${CONF_DIR}/${CLUSTER_NAME}"
 UGC_DIR="${DST_UGC_DIRECTORY:-${PERSISTENT_ROOT}/ugc_mods}"
 MOD_SYNC_MODE="${DST_MOD_SYNC_MODE:-reuse}"
+LEGACY_WORKSHOP_FALLBACK="${DST_LEGACY_WORKSHOP_FALLBACK:-1}"
+WORKSHOP_DETAILS_ENDPOINT="${DST_WORKSHOP_DETAILS_ENDPOINT:-https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/v1/}"
 
 server_bin() {
   if [[ -x "${SERVER_DIR}/bin64/dontstarve_dedicated_server_nullrenderer_x64" ]]; then
@@ -49,16 +51,138 @@ ensure_cluster_layout() {
 }
 
 configured_workshop_ids() {
-  local setup_file="${SERVER_DIR}/mods/dedicated_server_mods_setup.lua"
+  local setup_file="${CLUSTER_DIR}/dedicated_server_mods_setup.lua"
+  if [[ ! -f "${setup_file}" ]]; then
+    setup_file="${SERVER_DIR}/mods/dedicated_server_mods_setup.lua"
+  fi
   [[ -f "${setup_file}" ]] || return 0
   sed -n 's/^[[:space:]]*ServerModSetup("\([0-9][0-9]*\)").*/\1/p' "${setup_file}"
+}
+
+legacy_mod_dir() {
+  local ugc_dir="$1"
+  local workshop_id="$2"
+  printf '%s\n' "${ugc_dir}/legacy/workshop-${workshop_id}"
 }
 
 mod_is_cached() {
   local ugc_dir="$1"
   local workshop_id="$2"
   [[ -f "${ugc_dir}/content/322330/${workshop_id}/modinfo.lua" ]] \
-    || [[ -f "${SERVER_DIR}/mods/workshop-${workshop_id}/modinfo.lua" ]]
+    || [[ -f "$(legacy_mod_dir "${ugc_dir}" "${workshop_id}")/modinfo.lua" ]]
+}
+
+workshop_file_url() {
+  local workshop_id="$1"
+  local response
+  response="$(curl -fsS --retry 2 --connect-timeout 10 --max-time 30 \
+    -X POST "${WORKSHOP_DETAILS_ENDPOINT}" \
+    --data-urlencode "itemcount=1" \
+    --data-urlencode "publishedfileids[0]=${workshop_id}")" || return 1
+  printf '%s' "${response}" | sed -n 's/.*"file_url":"\([^"]*\)".*/\1/p'
+}
+
+download_legacy_workshop_mod() {
+  local ugc_dir="$1"
+  local workshop_id="$2"
+  local file_url="$3"
+  local target archive staging
+  target="$(legacy_mod_dir "${ugc_dir}" "${workshop_id}")"
+  archive="${ugc_dir}/.legacy-${workshop_id}.zip"
+  staging="${ugc_dir}/.legacy-${workshop_id}.tmp"
+
+  rm -rf "${archive}" "${staging}"
+  mkdir -p "${ugc_dir}" "${staging}"
+  echo "Downloading legacy DST Workshop mod ${workshop_id}..."
+  if ! curl -fL --retry 2 --connect-timeout 10 --max-time 180 --max-filesize 1073741824 \
+    "${file_url}" -o "${archive}"; then
+    rm -rf "${archive}" "${staging}"
+    return 1
+  fi
+  if unzip -Z1 "${archive}" | grep -Eq '(^/|(^|[/\\])\.\.([/\\]|$))'; then
+    echo "Legacy DST Workshop archive ${workshop_id} contains an unsafe path." >&2
+    rm -rf "${archive}" "${staging}"
+    return 1
+  fi
+  local unzip_status=0
+  unzip -oq "${archive}" -d "${staging}" || unzip_status=$?
+  # Info-ZIP returns 1 for warnings such as legacy archives that use Windows
+  # backslashes as separators, even when every file was extracted correctly.
+  if [[ "${unzip_status}" -gt 1 ]]; then
+    rm -rf "${archive}" "${staging}"
+    return 1
+  fi
+  rm -f "${archive}"
+  if [[ ! -f "${staging}/modinfo.lua" ]]; then
+    echo "Legacy DST Workshop archive ${workshop_id} has no root modinfo.lua." >&2
+    rm -rf "${staging}"
+    return 1
+  fi
+  rm -rf "${target}"
+  mkdir -p "$(dirname "${target}")"
+  mv "${staging}" "${target}"
+  echo "Downloaded legacy DST Workshop mod ${workshop_id}."
+}
+
+download_missing_legacy_mods() {
+  local ugc_dir="$1"
+  local workshop_id file_url
+  [[ "${LEGACY_WORKSHOP_FALLBACK}" == "1" ]] || return 0
+  while IFS= read -r workshop_id; do
+    [[ -n "${workshop_id}" ]] || continue
+    if mod_is_cached "${ugc_dir}" "${workshop_id}"; then
+      continue
+    fi
+    file_url="$(workshop_file_url "${workshop_id}")" || continue
+    [[ -n "${file_url}" ]] || continue
+    if ! download_legacy_workshop_mod "${ugc_dir}" "${workshop_id}" "${file_url}"; then
+      echo "Legacy DST Workshop download failed for ${workshop_id}; trying the native downloader." >&2
+    fi
+  done < <(configured_workshop_ids)
+}
+
+install_native_workshop_manifest() {
+  local ugc_dir="$1"
+  local setup_file="${SERVER_DIR}/mods/dedicated_server_mods_setup.lua"
+  local tmp_file="${setup_file}.tmp"
+  local workshop_id count=0
+  mkdir -p "${SERVER_DIR}/mods"
+  : >"${tmp_file}"
+  while IFS= read -r workshop_id; do
+    [[ -n "${workshop_id}" ]] || continue
+    if [[ -f "$(legacy_mod_dir "${ugc_dir}" "${workshop_id}")/modinfo.lua" ]]; then
+      continue
+    fi
+    printf 'ServerModSetup("%s")\n' "${workshop_id}" >>"${tmp_file}"
+    count=$((count + 1))
+  done < <(configured_workshop_ids)
+  if [[ "${count}" == "0" ]]; then
+    printf 'return nil\n' >"${tmp_file}"
+  fi
+  chmod 0644 "${tmp_file}"
+  mv "${tmp_file}" "${setup_file}"
+  printf '%s\n' "${count}"
+}
+
+install_legacy_mod_links() {
+  local workshop_id target link existing_target
+  mkdir -p "${SERVER_DIR}/mods"
+  while IFS= read -r link; do
+    existing_target="$(readlink "${link}")"
+    if [[ "${existing_target}" == "${UGC_DIR}/legacy/"* ]]; then
+      rm -f "${link}"
+    fi
+  done < <(find "${SERVER_DIR}/mods" -maxdepth 1 -type l -name 'workshop-*' -print)
+  while IFS= read -r workshop_id; do
+    [[ -n "${workshop_id}" ]] || continue
+    target="$(legacy_mod_dir "${UGC_DIR}" "${workshop_id}")"
+    link="${SERVER_DIR}/mods/workshop-${workshop_id}"
+    if [[ -f "${target}/modinfo.lua" ]]; then
+      rm -rf "${link}"
+      ln -s "${target}" "${link}"
+      echo "Linked legacy DST Workshop mod ${workshop_id}."
+    fi
+  done < <(configured_workshop_ids)
 }
 
 missing_workshop_ids() {
@@ -74,9 +198,15 @@ missing_workshop_ids() {
 
 download_server_mods() {
   local ugc_dir="$1"
-  local bin
+  local bin native_count
   bin="$(server_bin)"
   mkdir -p "${ugc_dir}" "${ugc_dir}/content/322330" "${ugc_dir}/downloads" "${ugc_dir}/temp"
+  download_missing_legacy_mods "${ugc_dir}"
+  native_count="$(install_native_workshop_manifest "${ugc_dir}")"
+  if [[ "${native_count}" == "0" ]]; then
+    echo "No native UGC Workshop mods require downloading."
+    return 0
+  fi
   cd "${SERVER_DIR}/bin64" 2>/dev/null || cd "${SERVER_DIR}/bin"
   "${bin}" \
     -only_update_server_mods \
@@ -151,6 +281,7 @@ start_shard() {
     -conf_dir "${CONF_DIR}" \
     -cluster "${CLUSTER_NAME}" \
     -shard "${shard}" \
+    -skip_update_server_mods \
     -ugc_directory "${UGC_DIR}"
 }
 
@@ -165,6 +296,8 @@ terminate_children() {
 
 ensure_cluster_layout
 sync_server_mods
+install_native_workshop_manifest "${UGC_DIR}" >/dev/null
+install_legacy_mod_links
 trap terminate_children TERM INT
 
 if [[ -f "${CLUSTER_DIR}/Caves/server.ini" ]]; then


### PR DESCRIPTION
## Summary
- download legacy V1 DST Workshop ZIPs from Steam's published-file API when UGC download is unavailable
- persist and link legacy mods into the runtime mods directory
- start Master and Caves with `-skip_update_server_mods` after the centralized sync
- add entrypoint coverage for legacy downloads and duplicate-update prevention

## Validation
- `go test ./...`
- `go vet ./...`
- local linux/amd64 image build
- real Fast Travel Workshop 458587300 download and DST load (Version 1.1.0, Mods registered)