### PR TITLE
fix: replace deprecated DST Fast Travel mod

### DIFF
--- a/apps/api/internal/modcatalog/catalog_test.go
+++ b/apps/api/internal/modcatalog/catalog_test.go
@@ -1,0 +1,26 @@
+package modcatalog
+
+import "testing"
+
+func TestRecommendedDSTModsUsesMaintainedFastTravel(t *testing.T) {
+	items, err := RecommendedDSTMods()
+	if err != nil {
+		t.Fatalf("load recommended DST mods: %v", err)
+	}
+
+	var foundMaintained bool
+	for _, item := range items {
+		if item.WorkshopID == "458587300" {
+			t.Fatal("legacy Fast Travel workshop item must not be recommended")
+		}
+		if item.WorkshopID == "1530801499" {
+			foundMaintained = true
+			if item.Title != "Fast Travel (GUI)" {
+				t.Fatalf("unexpected maintained Fast Travel title %q", item.Title)
+			}
+		}
+	}
+	if !foundMaintained {
+		t.Fatal("maintained Fast Travel workshop item is missing")
+	}
+}

--- a/apps/api/internal/modcatalog/recommended_dst_mods.json
+++ b/apps/api/internal/modcatalog/recommended_dst_mods.json
@@ -494,23 +494,24 @@
   },
   {
     "rank": 25,
-    "workshopId": "458587300",
-    "title": "Fast Travel",
-    "creatorSteamId": "76561198066992329",
-    "previewUrl": "https://images.steamusercontent.com/ugc/514881580594188793/6A7DD25C0BB632C34BF7E24364EA7B6C510C4B80/",
-    "fileSize": 48497,
-    "subscriptions": 1549548,
-    "favorited": 55170,
-    "views": 2171606,
-    "timeCreated": 1433937629,
-    "timeUpdated": 1460549306,
+    "workshopId": "1530801499",
+    "title": "Fast Travel (GUI)",
+    "creatorSteamId": "76561198326489103",
+    "previewUrl": "https://images.steamusercontent.com/ugc/945085057566751291/01A64689548956CC3208F2DEBFADE32113CB2365/",
+    "fileSize": 125426,
+    "subscriptions": 1008544,
+    "favorited": 39903,
+    "views": 1119242,
+    "timeCreated": 1538742119,
+    "timeUpdated": 1745758909,
     "tags": [
       "environment",
+      "tweak",
       "utility",
-      "version:1.1.0",
+      "version:1.10",
       "all_clients_require_mod"
     ],
-    "description": "Build a fast travel network using home signs. You can travel from one home sign to any other home signs instantly. Instruction - Right click on a home sign to select destination. Right click repeatedly to cycle through all available destinations. After hav"
+    "description": "Build a fast travel network with a destination selection interface. This maintained successor to the original Fast Travel mod also teleports nearby movable heavy objects."
   },
   {
     "rank": 26,


### PR DESCRIPTION
## Summary
- replace deprecated Fast Travel Workshop item 458587300 with Fast Travel (GUI) 1530801499
- refresh recommendation metadata from Steam
- add a catalog regression test so the legacy item is not recommended again

## Verification
- GOCACHE=/private/tmp/gamepanel-go-cache go test ./...
- GOCACHE=/private/tmp/gamepanel-go-cache go vet ./...