### PR TITLE
fix: filter false DST Workshop warnings

### DIFF
--- a/apps/api/internal/provider/dst/entrypoint_test.go
+++ b/apps/api/internal/provider/dst/entrypoint_test.go
@@ -126,6 +126,27 @@ cp "${url#file://}" "${out}"
 	}
 }
 
+func TestDSTEntrypointFiltersKnownNativeWorkshopNoise(t *testing.T) {
+	root, dataDir, script := dstEntrypointFixture(t, true)
+	t.Setenv("FAKE_WORKSHOP_NOISE", "1")
+
+	output, err := runDSTEntrypoint(t, root, dataDir, script, "refresh")
+	if err != nil {
+		t.Fatalf("run entrypoint: %v\n%s", err, output)
+	}
+	for _, noise := range []string{
+		"Staging library folder not found",
+		"Install library folder not found",
+	} {
+		if strings.Contains(output, noise) {
+			t.Fatalf("expected known Steam Workshop noise to be filtered, got:\n%s", output)
+		}
+	}
+	if !strings.Contains(output, "native downloader diagnostic") {
+		t.Fatalf("expected unrelated native downloader stderr to be preserved, got:\n%s", output)
+	}
+}
+
 func dstEntrypointFixture(t *testing.T, downloaderCreatesMods bool) (string, string, string) {
 	t.Helper()
 	root := t.TempDir()
@@ -144,6 +165,17 @@ if [[ " $* " == *" -only_update_server_mods "* ]]; then
     if [[ "$1" == "-ugc_directory" ]]; then ugc="$2"; break; fi
     shift
   done
+  for path in content/322330 downloads/322330 temp/322330; do
+    if [[ ! -d "${ugc}/${path}" ]]; then
+      printf 'missing UGC directory: %s\n' "${ugc}/${path}" >&2
+      exit 1
+    fi
+  done
+  if [[ "${FAKE_WORKSHOP_NOISE:-0}" == "1" ]]; then
+    printf '%s\n' 'src/clientdll/contentupdatecontext.cpp (2036) : Staging library folder not found' >&2
+    printf '%s\n' 'src/clientdll/contentupdatecontext.cpp (2037) : Install library folder not found' >&2
+    printf '%s\n' 'native downloader diagnostic' >&2
+  fi
   if [[ "${FAKE_DOWNLOAD_MODS:-0}" == "1" ]]; then
     for id in 111 222; do
       mkdir -p "${ugc}/content/322330/${id}"

--- a/docker/dst/gamepanel-dst-entrypoint.sh
+++ b/docker/dst/gamepanel-dst-entrypoint.sh
@@ -185,6 +185,15 @@ install_legacy_mod_links() {
   done < <(configured_workshop_ids)
 }
 
+filter_native_workshop_noise() {
+  # Steam emits these internal contentupdatecontext assertions even when a V2
+  # Workshop download completes successfully. Keep all other stderr output;
+  # missing mods are still rejected by missing_workshop_ids after the process.
+  sed -E \
+    -e '/^src\/clientdll\/contentupdatecontext\.cpp \(2036\) : Staging library folder not found$/d' \
+    -e '/^src\/clientdll\/contentupdatecontext\.cpp \(2037\) : Install library folder not found$/d'
+}
+
 missing_workshop_ids() {
   local ugc_dir="$1"
   local workshop_id
@@ -200,7 +209,10 @@ download_server_mods() {
   local ugc_dir="$1"
   local bin native_count
   bin="$(server_bin)"
-  mkdir -p "${ugc_dir}" "${ugc_dir}/content/322330" "${ugc_dir}/downloads" "${ugc_dir}/temp"
+  mkdir -p \
+    "${ugc_dir}/content/322330" \
+    "${ugc_dir}/downloads/322330" \
+    "${ugc_dir}/temp/322330"
   download_missing_legacy_mods "${ugc_dir}"
   native_count="$(install_native_workshop_manifest "${ugc_dir}")"
   if [[ "${native_count}" == "0" ]]; then
@@ -214,7 +226,8 @@ download_server_mods() {
     -conf_dir "${CONF_DIR}" \
     -cluster "${CLUSTER_NAME}" \
     -shard "Master" \
-    -ugc_directory "${ugc_dir}"
+    -ugc_directory "${ugc_dir}" \
+    2>&1 | filter_native_workshop_noise
 }
 
 sync_server_mods() {


### PR DESCRIPTION
## Summary
- initialize app-specific UGC content, downloads, and temp directories
- filter only Steam's known false-positive contentupdatecontext staging/install assertions
- retain downloader exit status and post-download cache integrity checks
- add regression coverage proving unrelated stderr remains visible

## Verification
- real linux/amd64 DST container downloaded and loaded Fast Travel (GUI) 1.10 without the false warning lines
- GOCACHE=/private/tmp/gamepanel-go-cache go test ./...
- GOCACHE=/private/tmp/gamepanel-go-cache go vet ./...
- bash -n docker/dst/gamepanel-dst-entrypoint.sh