### PR TITLE
fix: persist DST cave shard identity

### DIFF
--- a/apps/api/internal/http/server_handlers_test.go
+++ b/apps/api/internal/http/server_handlers_test.go
@@ -508,7 +508,8 @@ func TestCreateDSTServerUsesDSTRuntimeSpec(t *testing.T) {
 	gameplay, _ := server.Spec.Config["gameplay"].(map[string]any)
 	world, _ := server.Spec.Config["world"].(map[string]any)
 	caves, _ := server.Spec.Config["caves"].(map[string]any)
-	if identity["clusterName"] != "FriendsCluster" || identity["clusterToken"] != "klei-token" || gameplay["gameMode"] != "endless" || world["preset"] != "forest_classic" || caves["enabled"] != true {
+	shards, _ := server.Spec.Config["shards"].(map[string]any)
+	if identity["clusterName"] != "FriendsCluster" || identity["clusterToken"] != "klei-token" || gameplay["gameMode"] != "endless" || world["preset"] != "forest_classic" || caves["enabled"] != true || shards["cavesId"] != "2" {
 		t.Fatalf("expected semantic DST config payload, got %+v", server.Spec.Config)
 	}
 
@@ -535,13 +536,35 @@ func TestCreateDSTServerUsesDSTRuntimeSpec(t *testing.T) {
 	if !strings.Contains(spec.Options.Files["dst/FriendsCluster/Master/leveldataoverride.lua"], `preset = "forest_classic"`) {
 		t.Fatalf("expected DST world preset in runtime files, got %+v", spec.Options.Files)
 	}
-	if _, ok := spec.Options.Files["dst/FriendsCluster/Caves/server.ini"]; !ok {
+	cavesINI, ok := spec.Options.Files["dst/FriendsCluster/Caves/server.ini"]
+	if !ok {
 		t.Fatalf("expected DST caves shard files, got %+v", spec.Options.Files)
+	}
+	if !strings.Contains(cavesINI, "id = 2") {
+		t.Fatalf("expected stable default caves shard id, got:\n%s", cavesINI)
 	}
 	if spec.Options.Files["dst/FriendsCluster/cluster_token.txt"] != "klei-token\n" {
 		t.Fatalf("expected DST token file, got %q", spec.Options.Files["dst/FriendsCluster/cluster_token.txt"])
 	}
 	waitForServerStatus(t, db, server.ID, domain.StatusRunning)
+
+	update := httptest.NewRecorder()
+	router.ServeHTTP(update, httptest.NewRequest(
+		stdhttp.MethodPut,
+		"/api/servers/"+server.ID+"/config",
+		strings.NewReader(`{"config":{"gameplay":{"maxPlayers":8}}}`),
+	))
+	if update.Code != stdhttp.StatusOK {
+		t.Fatalf("expected config update 200, got %d: %s", update.Code, update.Body.String())
+	}
+	var updated domain.GameServer
+	if err := json.Unmarshal(update.Body.Bytes(), &updated); err != nil {
+		t.Fatal(err)
+	}
+	updatedShards, _ := updated.Spec.Config["shards"].(map[string]any)
+	if updatedShards["cavesId"] != "2" {
+		t.Fatalf("expected cave shard id to survive config updates, got %+v", updated.Spec.Config)
+	}
 }
 
 func TestCreateDSTServerRejectsArmRuntime(t *testing.T) {

--- a/apps/api/internal/provider/dst/provider.go
+++ b/apps/api/internal/provider/dst/provider.go
@@ -3,7 +3,10 @@ package dst
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/smartcat999/game-panel-lite/apps/api/internal/domain"
@@ -12,7 +15,10 @@ import (
 	"github.com/smartcat999/game-panel-lite/apps/api/internal/runtime"
 )
 
-const DefaultInternalPort = 10999
+const (
+	DefaultInternalPort = 10999
+	DefaultCavesShardID = "2"
+)
 
 var versions = []string{"v2026.07.17", "v2026.06.21"}
 
@@ -26,6 +32,7 @@ type Config struct {
 	World    DSTWorldConfig
 	Caves    *DSTCaveConfig
 	Mods     DSTModConfig
+	Shards   DSTShardConfig
 	Port     int
 }
 
@@ -62,6 +69,10 @@ type DSTModConfig struct {
 	WorkshopIDs    []string
 	ModPackIDs     []string
 	Configurations map[string]map[string]any
+}
+
+type DSTShardConfig struct {
+	CavesID string
 }
 
 func NewProvider(catalog ...runtimecatalog.Catalog) Provider {
@@ -186,6 +197,10 @@ func validateConfig(config Config) error {
 		if config.Caves.Enabled && strings.TrimSpace(config.Caves.Preset) == "" {
 			return fmt.Errorf("cave preset is required")
 		}
+		shardID, err := strconv.ParseUint(config.Shards.CavesID, 10, 32)
+		if err != nil || shardID <= 1 {
+			return fmt.Errorf("cave shard id must be an integer between 2 and 4294967295")
+		}
 		for key, value := range config.Caves.Overrides {
 			if err := validateOverride(key, value); err != nil {
 				return fmt.Errorf("cave override %s: %w", key, err)
@@ -244,7 +259,7 @@ func runtimeOptions(config Config) runtime.ContainerOptions {
 		Files: map[string]string{
 			clusterDir + "/cluster.ini":                     renderClusterINI(config),
 			clusterDir + "/cluster_token.txt":               strings.TrimSpace(config.Identity.ClusterToken) + "\n",
-			clusterDir + "/Master/server.ini":               renderShardServerINI(config.Port, true, "Master"),
+			clusterDir + "/Master/server.ini":               renderShardServerINI(config.Port, true, "Master", ""),
 			clusterDir + "/Master/leveldataoverride.lua":    renderLevelDataOverrideLua("forest", config.World.Preset, config.World.Overrides),
 			clusterDir + "/Master/modoverrides.lua":         renderModOverrides(serverModIDs, config.Mods.Configurations),
 			clusterDir + "/dedicated_server_mods_setup.lua": renderWorkshopSetup(serverModIDs),
@@ -261,12 +276,15 @@ func (p Provider) RuntimeConfigForResource(server domain.GameServer) (domain.Pro
 	if err := validateConfig(config); err != nil {
 		return domain.ProviderRuntimeConfig{}, err
 	}
+	if existingID := existingCavesShardID(server.Spec.Runtime.DataDir, clusterConfigDir(config)); existingID != "" {
+		config.Shards.CavesID = existingID
+	}
 	options := runtimeOptions(config)
 	clusterDir := clusterConfigDir(config)
 	options.Files[clusterDir+"/cluster.ini"] = renderClusterINI(config)
 	options.Files[clusterDir+"/Master/leveldataoverride.lua"] = renderLevelDataOverrideLua("forest", config.World.Preset, config.World.Overrides)
 	if config.Caves != nil && config.Caves.Enabled {
-		options.Files[clusterDir+"/Caves/server.ini"] = renderShardServerINI(config.Port+1, false, "Caves")
+		options.Files[clusterDir+"/Caves/server.ini"] = renderShardServerINI(config.Port+1, false, "Caves", config.Shards.CavesID)
 		options.Files[clusterDir+"/Caves/leveldataoverride.lua"] = renderLevelDataOverrideLua("cave", config.Caves.Preset, config.Caves.Overrides)
 		options.Files[clusterDir+"/Caves/modoverrides.lua"] = renderModOverrides(serverWorkshopIDs(config.Mods.WorkshopIDs), config.Mods.Configurations)
 	}
@@ -332,6 +350,9 @@ func normalizeConfig(config Config) Config {
 	if strings.TrimSpace(config.World.Preset) == "" {
 		config.World.Preset = "forest_default"
 	}
+	if strings.TrimSpace(config.Shards.CavesID) == "" {
+		config.Shards.CavesID = DefaultCavesShardID
+	}
 	config.World.Overrides = cleanOverrides(config.World.Overrides)
 	if config.Caves != nil {
 		if strings.TrimSpace(config.Caves.Preset) == "" {
@@ -388,6 +409,9 @@ func configFromPayload(payload map[string]any, fallback Config) Config {
 			Overrides: stringMapPayload(caves, "overrides"),
 		}
 	}
+	if shards := objectPayload(payload, "shards"); shards != nil {
+		config.Shards.CavesID = stringPayload(shards, "cavesId")
+	}
 	if mods := objectPayload(payload, "mods"); mods != nil {
 		config.Mods.WorkshopIDs = workshopIDsPayload(mods, "workshopIds")
 		config.Mods.ModPackIDs = stringSlicePayload(mods, "modPackIds")
@@ -422,6 +446,9 @@ func payloadFromConfig(config Config) map[string]any {
 			"workshopIds":    append([]string{}, config.Mods.WorkshopIDs...),
 			"modPackIds":     append([]string{}, config.Mods.ModPackIDs...),
 			"configurations": cloneModConfigurations(config.Mods.Configurations),
+		},
+		"shards": map[string]any{
+			"cavesId": config.Shards.CavesID,
 		},
 	}
 	identity := payload["identity"].(map[string]any)
@@ -498,20 +525,46 @@ func clusterConfigDir(config Config) string {
 	return "dst/" + config.Identity.ClusterName
 }
 
-func renderShardServerINI(port int, isMaster bool, name string) string {
+func existingCavesShardID(dataDir string, clusterDir string) string {
+	if strings.TrimSpace(dataDir) == "" {
+		return ""
+	}
+	content, err := os.ReadFile(filepath.Join(dataDir, filepath.FromSlash(clusterDir), "Caves", "server.ini"))
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(content), "\n") {
+		key, value, found := strings.Cut(line, "=")
+		if !found || strings.TrimSpace(key) != "id" {
+			continue
+		}
+		shardID := strings.TrimSpace(value)
+		parsed, parseErr := strconv.ParseUint(shardID, 10, 32)
+		if parseErr == nil && parsed > 1 {
+			return shardID
+		}
+	}
+	return ""
+}
+
+func renderShardServerINI(port int, isMaster bool, name string, shardID string) string {
 	master := "false"
 	if isMaster {
 		master = "true"
 	}
-	return strings.Join([]string{
+	lines := []string{
 		"[NETWORK]",
 		fmt.Sprintf("server_port = %d", port),
 		"",
 		"[SHARD]",
 		"is_master = " + master,
 		"name = " + name,
-		"",
-	}, "\n")
+	}
+	if !isMaster && strings.TrimSpace(shardID) != "" {
+		lines = append(lines, "id = "+strings.TrimSpace(shardID))
+	}
+	lines = append(lines, "")
+	return strings.Join(lines, "\n")
 }
 
 func renderLevelDataOverrideLua(location string, preset string, overrides map[string]string) string {

--- a/apps/api/internal/provider/dst/provider_test.go
+++ b/apps/api/internal/provider/dst/provider_test.go
@@ -1,6 +1,8 @@
 package dst
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -186,6 +188,97 @@ func TestNormalizeAndValidateConfig(t *testing.T) {
 	bad.Identity.ClusterToken = ""
 	if err := validateConfig(bad); err == nil {
 		t.Fatal("expected missing Klei token to fail")
+	}
+}
+
+func TestCavesShardIDIsStableAndPersisted(t *testing.T) {
+	provider := NewProvider()
+	normalized, err := provider.NormalizeConfigPayload(map[string]any{
+		"identity": map[string]any{
+			"serverName":   "DST Friends",
+			"clusterName":  "Cluster",
+			"clusterToken": "klei-token",
+		},
+		"caves": map[string]any{"enabled": true},
+		"shards": map[string]any{
+			"cavesId": "4286217238",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	shards, _ := normalized["shards"].(map[string]any)
+	if got := shards["cavesId"]; got != "4286217238" {
+		t.Fatalf("expected cave shard id to persist, got %v", got)
+	}
+
+	runtimeConfig, err := provider.RuntimeConfigForResource(domain.GameServer{
+		Spec: domain.ServerSpec{Config: normalized},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverINI := runtimeConfig.Options.Files["dst/Cluster/Caves/server.ini"]
+	if !strings.Contains(serverINI, "id = 4286217238") {
+		t.Fatalf("expected persisted cave shard id in server.ini, got:\n%s", serverINI)
+	}
+}
+
+func TestCavesShardIDDefaultsAndValidates(t *testing.T) {
+	config := defaultConfig()
+	config.Identity.ClusterToken = "klei-token"
+	config.Caves = &DSTCaveConfig{Enabled: true, Preset: "cave_default"}
+	if config.Shards.CavesID != DefaultCavesShardID {
+		t.Fatalf("expected default cave shard id %q, got %q", DefaultCavesShardID, config.Shards.CavesID)
+	}
+	if err := validateConfig(config); err != nil {
+		t.Fatalf("expected default cave shard id to validate: %v", err)
+	}
+
+	for _, invalid := range []string{"1", "0", "-2", "not-a-number", "4294967296"} {
+		bad := config
+		bad.Shards.CavesID = invalid
+		if err := validateConfig(bad); err == nil {
+			t.Fatalf("expected cave shard id %q to fail validation", invalid)
+		}
+	}
+}
+
+func TestExistingCavesShardIDWinsDuringRuntimePreparation(t *testing.T) {
+	dataDir := t.TempDir()
+	cavesDir := filepath.Join(dataDir, "dst", "Cluster", "Caves")
+	if err := os.MkdirAll(cavesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(cavesDir, "server.ini"),
+		[]byte("[SHARD]\nis_master = false\nname = Caves\nid = 4286217238\n"),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	provider := NewProvider()
+	runtimeConfig, err := provider.RuntimeConfigForResource(domain.GameServer{
+		Spec: domain.ServerSpec{
+			Config: map[string]any{
+				"identity": map[string]any{
+					"serverName":   "DST Friends",
+					"clusterName":  "Cluster",
+					"clusterToken": "klei-token",
+				},
+				"caves":  map[string]any{"enabled": true},
+				"shards": map[string]any{"cavesId": DefaultCavesShardID},
+			},
+			Runtime: domain.ServerRuntimeSpec{DataDir: dataDir},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverINI := runtimeConfig.Options.Files["dst/Cluster/Caves/server.ini"]
+	if !strings.Contains(serverINI, "id = 4286217238") {
+		t.Fatalf("expected existing on-disk cave shard id to win, got:\n%s", serverINI)
 	}
 }
 


### PR DESCRIPTION
## Summary
- persist a stable Caves shard ID in normalized DST server configuration
- preserve an existing on-disk Caves ID during runtime preparation for upgrade compatibility
- render and validate the shard ID in `Caves/server.ini`
- cover creation, config updates, existing installations, and invalid IDs with tests

## Production recovery
- restored the affected Caves shard to ID `4286217238`
- verified Master reports `Caves(4286217238) ready`

## Validation
- `go test ./apps/api/internal/provider/dst`
- `go test ./apps/api/internal/http -run ^TestCreateDSTServerUsesDSTRuntimeSpec$ -count=1`
- `go vet ./...`
- `go build ./...`
- `go test ./...` runs all packages but the existing Palworld update preflight test fails locally because the workstation has 6.1 GiB free and that test requires 8 GiB