### PR TITLE
feat: update Palworld runtime to v2.7.1

### DIFF
--- a/apps/api/internal/http/server_handlers_test.go
+++ b/apps/api/internal/http/server_handlers_test.go
@@ -451,7 +451,7 @@ func TestCreatePalworldServerUsesPalworldRuntimeSpec(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("expected async start to create runtime container")
 	}
-	if spec.Image != "smartcat99999/palworld-server:v2.5.0" {
+	if spec.Image != "smartcat99999/palworld-server:v2.7.1" {
 		t.Fatalf("expected Palworld image, got %q", spec.Image)
 	}
 	if spec.Port != 8211 || spec.Options.PortProtocol != "udp" {

--- a/apps/api/internal/provider/palworld/provider.go
+++ b/apps/api/internal/provider/palworld/provider.go
@@ -13,7 +13,7 @@ import (
 
 const DefaultInternalPort = 8211
 
-var versions = []string{"v2.5.0", "v2.4.2", "v2.4.1"}
+var versions = []string{"v2.7.1", "v2.5.0", "v2.4.2", "v2.4.1"}
 
 var ansiEscapePattern = regexp.MustCompile(`\x1b\[[0-9;]*[A-Za-z]`)
 

--- a/apps/api/internal/provider/palworld/provider_test.go
+++ b/apps/api/internal/provider/palworld/provider_test.go
@@ -81,7 +81,7 @@ func TestRuntimeOptionsUsePalworldImageAndUdpPort(t *testing.T) {
 	provider := NewProvider()
 	options := runtimeOptions(config)
 
-	if provider.ImageFor("") != "smartcat99999/palworld-server:v2.5.0" {
+	if provider.ImageFor("") != "smartcat99999/palworld-server:v2.7.1" {
 		t.Fatalf("unexpected Palworld image: %s", provider.ImageFor(""))
 	}
 	if options.PortProtocol != "udp" {

--- a/config/providers.json
+++ b/config/providers.json
@@ -19,7 +19,7 @@
     },
     "palworld": {
       "imageTemplate": "{registry}/palworld-server:{version}",
-      "versions": ["v2.5.0", "v2.4.2", "v2.4.1"]
+      "versions": ["v2.7.1", "v2.5.0", "v2.4.2", "v2.4.1"]
     },
     "minecraft": {
       "image": "{registry}/minecraft-server:2026.6.0-java21",

--- a/docker/palworld/Dockerfile
+++ b/docker/palworld/Dockerfile
@@ -1,12 +1,11 @@
-ARG PALWORLD_RUNTIME_VERSION=v2.5.0
+ARG PALWORLD_RUNTIME_VERSION=v2.7.1
 FROM thijsvanloef/palworld-server-docker:${PALWORLD_RUNTIME_VERSION}
 
 COPY docker/palworld/patch_pal_logger.py /tmp/patch_pal_logger.py
 
-# The upstream logger is started asynchronously as root. It can recreate its
-# private FIFO after init.sh has already chowned /home/steam, leaving the game
-# helper unable to write log events. Patch the logger to publish a correctly
-# owned FIFO atomically and fail the build if the upstream block changes.
+# Validate that the upstream logger either uses its fixed init.sh-managed FIFO
+# lifecycle or matches the older layout that GamePanel patches atomically.
+# Unknown layouts fail the build instead of silently reintroducing log loss.
 RUN python3 /tmp/patch_pal_logger.py /home/steam/server/pal_logger.py \
     && python3 -m py_compile /home/steam/server/pal_logger.py \
     && rm -rf /tmp/patch_pal_logger.py /home/steam/server/__pycache__

--- a/docker/palworld/README.md
+++ b/docker/palworld/README.md
@@ -2,12 +2,11 @@
 
 This image packages the stable `thijsvanloef/palworld-server-docker` runtime under the GamePanel Lite image namespace. GamePanel sets `UPDATE_ON_BOOT=false` after the initial installation so ordinary container restarts reuse the installed Palworld Dedicated Server files instead of verifying roughly 5 GB through SteamCMD every time. Runtime image upgrades are managed explicitly by GamePanel.
 
-The image also fixes an upstream startup race in `pal_logger.py`. The upstream
-logger can recreate its private log FIFO as `root:root` with mode `0600` after
-the initialization script has already changed `/home/steam` to the configured
-`PUID` and `PGID`. GamePanel's build-time patch creates a private temporary FIFO,
-sets its final owner and mode, and atomically publishes it. The build fails if
-the expected upstream code changes, preventing a silently stale patch.
+The image validates the upstream `pal_logger.py` FIFO lifecycle at build time.
+Older upstream releases are patched to publish the FIFO with its final owner
+atomically. Current releases manage FIFO creation and ownership in `init.sh`;
+the validator accepts that fixed implementation and fails the build for unknown
+layouts so a logging permission regression cannot ship silently.
 
 Build and load the current version for the local Docker architecture:
 
@@ -24,14 +23,14 @@ scripts/build-game-images.sh palworld --platform linux/amd64,linux/arm64 --push
 Override the upstream runtime tag when testing a newer release:
 
 ```bash
-PALWORLD_RUNTIME_VERSION=v2.5.0 scripts/build-game-images.sh palworld --load
+PALWORLD_RUNTIME_VERSION=v2.7.1 scripts/build-game-images.sh palworld --load
 ```
 
 Keep the upstream base version separate from an immutable GamePanel image tag:
 
 ```bash
-PALWORLD_RUNTIME_VERSION=v2.5.0 \
-PALWORLD_IMAGE_VERSION=v2.5.0-gamepanel.1 \
+PALWORLD_RUNTIME_VERSION=v2.7.1 \
+PALWORLD_IMAGE_VERSION=v2.7.1-gamepanel.1 \
 scripts/build-game-images.sh palworld --platform linux/amd64 --push
 ```
 
@@ -48,6 +47,6 @@ non-root game helper writes to the FIFO:
 docker run --rm --platform linux/amd64 \
   --entrypoint /bin/bash \
   -v "$PWD/docker/palworld/test_fifo_runtime.sh:/tmp/test_fifo_runtime.sh:ro" \
-  smartcat99999/palworld-server:v2.5.0-gamepanel.1 \
+  smartcat99999/palworld-server:v2.7.1-gamepanel.1 \
   /tmp/test_fifo_runtime.sh
 ```

--- a/docker/palworld/patch_pal_logger.py
+++ b/docker/palworld/patch_pal_logger.py
@@ -8,6 +8,11 @@ import sys
 
 
 PATCH_MARKER = "# GamePanel Lite: publish the FIFO with its final owner atomically."
+UPSTREAM_MANAGED_MARKERS = (
+    "# FIFO lifecycle (create/remove/chown) is managed by init.sh.",
+    'if not os.path.exists(FIFO_PATH):',
+    'fifo_fd = os.open(FIFO_PATH, os.O_RDWR | os.O_NONBLOCK)',
+)
 
 UPSTREAM_BLOCK = '''# Setup FIFO
 if os.path.exists(FIFO_PATH):
@@ -61,6 +66,8 @@ def patch(path: pathlib.Path) -> bool:
     source = path.read_text(encoding="utf-8")
     if PATCH_MARKER in source:
         return False
+    if all(marker in source for marker in UPSTREAM_MANAGED_MARKERS):
+        return False
     matches = source.count(UPSTREAM_BLOCK)
     if matches != 1:
         raise RuntimeError(
@@ -76,7 +83,7 @@ def main(argv: list[str]) -> int:
         return 2
     target = pathlib.Path(argv[1])
     changed = patch(target)
-    print(f"{'patched' if changed else 'already patched'} {target}")
+    print(f"{'patched' if changed else 'validated'} {target}")
     return 0
 
 

--- a/docker/palworld/test_fifo_runtime.sh
+++ b/docker/palworld/test_fifo_runtime.sh
@@ -10,6 +10,10 @@ readonly test_gid=12002
 rm -f "${fifo}" "${stdout_file}" "${stderr_file}"
 # Mirror init.sh changing the steam home to the configured runtime identity.
 chown "${test_uid}:${test_gid}" /home/steam
+# Upstream v2.7.1 and newer manage the FIFO in init.sh before starting the
+# logger. Older GamePanel-patched loggers safely replace this FIFO themselves.
+mkfifo -m 600 "${fifo}"
+chown "${test_uid}:${test_gid}" "${fifo}"
 
 tail -f /dev/null | env PUID="${test_uid}" PGID="${test_gid}" \
   python3 /home/steam/server/pal_logger.py >"${stdout_file}" 2>"${stderr_file}" &

--- a/docker/palworld/test_patch_pal_logger.py
+++ b/docker/palworld/test_patch_pal_logger.py
@@ -36,6 +36,15 @@ class PatchPalLoggerTest(unittest.TestCase):
             with self.assertRaisesRegex(RuntimeError, "found 0"):
                 PATCHER.patch(path)
 
+    def test_upstream_managed_fifo_is_accepted_without_changes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = pathlib.Path(directory, "pal_logger.py")
+            source = "\n".join(PATCHER.UPSTREAM_MANAGED_MARKERS) + "\n"
+            path.write_text(source, encoding="utf-8")
+
+            self.assertFalse(PATCHER.patch(path))
+            self.assertEqual(source, path.read_text(encoding="utf-8"))
+
     def test_non_root_fifo_is_atomically_published_with_private_mode(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             fifo = pathlib.Path(directory, "events.fifo")

--- a/scripts/build-game-images.sh
+++ b/scripts/build-game-images.sh
@@ -155,7 +155,7 @@ build_dst() {
 }
 
 build_palworld() {
-  local runtime_version="${PALWORLD_RUNTIME_VERSION:-v2.5.0}"
+  local runtime_version="${PALWORLD_RUNTIME_VERSION:-v2.7.1}"
   local image_version="${PALWORLD_IMAGE_VERSION:-${runtime_version}}"
   local image="${registry}/palworld-server:${image_version}"
 


### PR DESCRIPTION
## Summary
- make Palworld runtime v2.7.1 the default for newly created servers
- retain older runtime versions for existing instances
- accept the upstream init.sh-managed FIFO lifecycle while preserving the legacy compatibility patch
- refresh build and runtime validation docs

## Validation
- go test ./...
- go vet ./...
- pnpm --dir apps/web build
- Python Palworld logger patch tests
- linux/amd64 image build
- non-root FIFO runtime test
- pushed matching image digest to Docker Hub and Aliyun