### PR TITLE
fix: preserve Steam collection titles

### DIFF
--- a/apps/api/internal/http/workshop_handlers.go
+++ b/apps/api/internal/http/workshop_handlers.go
@@ -36,12 +36,13 @@ type workshopPreviewSummary struct {
 }
 
 type workshopPreviewResponse struct {
-	PreviewID    string                 `json:"previewId"`
-	CollectionID string                 `json:"collectionId"`
-	ProviderKey  domain.ProviderKey     `json:"providerKey"`
-	ExpiresAt    time.Time              `json:"expiresAt"`
-	Items        []workshopPreviewItem  `json:"items"`
-	Summary      workshopPreviewSummary `json:"summary"`
+	PreviewID      string                 `json:"previewId"`
+	CollectionID   string                 `json:"collectionId"`
+	CollectionName string                 `json:"collectionName,omitempty"`
+	ProviderKey    domain.ProviderKey     `json:"providerKey"`
+	ExpiresAt      time.Time              `json:"expiresAt"`
+	Items          []workshopPreviewItem  `json:"items"`
+	Summary        workshopPreviewSummary `json:"summary"`
 }
 
 func (h *Handler) previewWorkshopCollection(w http.ResponseWriter, r *http.Request) {
@@ -102,13 +103,14 @@ func (h *Handler) previewWorkshopCollection(w http.ResponseWriter, r *http.Reque
 	}
 
 	response := workshopPreviewResponse{
-		PreviewID:    uuid.NewString(),
-		CollectionID: collection.ID,
-		ProviderKey:  payload.ProviderKey,
-		ExpiresAt:    time.Now().Add(workshopPreviewTTL),
-		Items:        make([]workshopPreviewItem, 0, len(collection.Items)),
+		PreviewID:      uuid.NewString(),
+		CollectionID:   collection.ID,
+		CollectionName: collection.Title,
+		ProviderKey:    payload.ProviderKey,
+		ExpiresAt:      time.Now().Add(workshopPreviewTTL),
+		Items:          make([]workshopPreviewItem, 0, len(collection.Items)),
 	}
-	importableCollection := workshopsvc.Collection{ID: collection.ID, Items: make([]workshopsvc.Item, 0, len(collection.Items))}
+	importableCollection := workshopsvc.Collection{ID: collection.ID, Title: collection.Title, Items: make([]workshopsvc.Item, 0, len(collection.Items))}
 	for _, item := range collection.Items {
 		status := "new"
 		selectable := true

--- a/apps/api/internal/http/workshop_handlers_test.go
+++ b/apps/api/internal/http/workshop_handlers_test.go
@@ -42,7 +42,8 @@ func TestWorkshopCollectionPreviewMarksExistingItemsAndCachesMetadata(t *testing
 	handler := &Handler{
 		store: db,
 		workshopResolver: staticWorkshopResolver{collection: workshopsvc.Collection{
-			ID: "900",
+			ID:    "900",
+			Title: "Friends Pack",
 			Items: []workshopsvc.Item{
 				{WorkshopID: "100", Title: "Existing"},
 				{WorkshopID: "200", Title: "New Mod", FileSize: 2048, Tags: []string{"New Content"}},
@@ -66,6 +67,9 @@ func TestWorkshopCollectionPreviewMarksExistingItemsAndCachesMetadata(t *testing
 	}
 	if response.PreviewID == "" || len(response.Items) != 2 {
 		t.Fatalf("unexpected response: %+v", response)
+	}
+	if response.CollectionName != "Friends Pack" {
+		t.Fatalf("expected collection name in preview, got %+v", response)
 	}
 	selected, err := handler.workshopPreviewItems(response.PreviewID, domain.ProviderTerrariaTModLoader, "", []string{"200"})
 	if err != nil {

--- a/apps/api/internal/workshop/steam.go
+++ b/apps/api/internal/workshop/steam.go
@@ -59,14 +59,14 @@ func (r *SteamResolver) ResolveCollection(ctx context.Context, providerKey domai
 	if len(itemIDs) > MaxCollectionItems {
 		return Collection{}, ErrCollectionTooLarge
 	}
-	items, err := r.publishedFileDetails(ctx, itemIDs, appID)
+	title, items, err := r.publishedFileDetails(ctx, collectionID, itemIDs, appID)
 	if err != nil {
 		return Collection{}, err
 	}
 	if len(items) == 0 {
 		return Collection{}, fmt.Errorf("%w: collection has no compatible items", ErrInvalidCollection)
 	}
-	return Collection{ID: collectionID, Items: items}, nil
+	return Collection{ID: collectionID, Title: title, Items: items}, nil
 }
 
 func ParseCollectionID(input string) (string, error) {
@@ -170,26 +170,31 @@ func (r *SteamResolver) collectionDetails(ctx context.Context, ids []string) (ma
 	return result, nil
 }
 
-func (r *SteamResolver) publishedFileDetails(ctx context.Context, ids []string, expectedAppID int) ([]Item, error) {
+func (r *SteamResolver) publishedFileDetails(ctx context.Context, collectionID string, ids []string, expectedAppID int) (string, []Item, error) {
+	allIDs := append([]string{collectionID}, ids...)
+	collectionTitle := ""
 	items := make([]Item, 0, len(ids))
-	for start := 0; start < len(ids); start += steamBatchSize {
+	for start := 0; start < len(allIDs); start += steamBatchSize {
 		end := start + steamBatchSize
-		if end > len(ids) {
-			end = len(ids)
+		if end > len(allIDs) {
+			end = len(allIDs)
 		}
-		batch, err := r.publishedFileDetailsBatch(ctx, ids[start:end], expectedAppID)
+		title, batch, err := r.publishedFileDetailsBatch(ctx, allIDs[start:end], expectedAppID, collectionID)
 		if err != nil {
-			return nil, err
+			return "", nil, err
+		}
+		if title != "" {
+			collectionTitle = title
 		}
 		items = append(items, batch...)
 	}
 	sort.Slice(items, func(i, j int) bool {
 		return strings.ToLower(items[i].Title) < strings.ToLower(items[j].Title)
 	})
-	return items, nil
+	return collectionTitle, items, nil
 }
 
-func (r *SteamResolver) publishedFileDetailsBatch(ctx context.Context, ids []string, expectedAppID int) ([]Item, error) {
+func (r *SteamResolver) publishedFileDetailsBatch(ctx context.Context, ids []string, expectedAppID int, collectionID string) (string, []Item, error) {
 	form := url.Values{"itemcount": {strconv.Itoa(len(ids))}}
 	for i, id := range ids {
 		form.Set(fmt.Sprintf("publishedfileids[%d]", i), id)
@@ -218,10 +223,17 @@ func (r *SteamResolver) publishedFileDetailsBatch(ctx context.Context, ids []str
 		} `json:"response"`
 	}
 	if err := r.postForm(ctx, "/ISteamRemoteStorage/GetPublishedFileDetails/v1/", form, &payload); err != nil {
-		return nil, err
+		return "", nil, err
 	}
+	collectionTitle := ""
 	items := make([]Item, 0, len(payload.Response.PublishedFileDetails))
 	for _, detail := range payload.Response.PublishedFileDetails {
+		if detail.PublishedFileID == collectionID {
+			if detail.Result == 1 && detail.ConsumerAppID == expectedAppID && detail.FileType == 2 {
+				collectionTitle = truncateRunes(strings.TrimSpace(detail.Title), 300)
+			}
+			continue
+		}
 		if detail.Result != 1 || detail.ConsumerAppID != expectedAppID || detail.FileType == 2 || !isDigits(detail.PublishedFileID) {
 			continue
 		}
@@ -249,7 +261,7 @@ func (r *SteamResolver) publishedFileDetailsBatch(ctx context.Context, ids []str
 			Tags:           tags,
 		})
 	}
-	return items, nil
+	return collectionTitle, items, nil
 }
 
 func (r *SteamResolver) postForm(ctx context.Context, path string, form url.Values, target any) error {

--- a/apps/api/internal/workshop/steam_test.go
+++ b/apps/api/internal/workshop/steam_test.go
@@ -61,10 +61,11 @@ func TestSteamResolverExpandsCollectionAndFiltersAppID(t *testing.T) {
 			}
 			t.Fatalf("unexpected collection id %q", id)
 		case "/ISteamRemoteStorage/GetPublishedFileDetails/v1/":
-			if r.Form.Get("itemcount") != "2" {
+			if r.Form.Get("itemcount") != "3" {
 				t.Fatalf("unexpected itemcount %q", r.Form.Get("itemcount"))
 			}
 			fmt.Fprint(w, `{"response":{"publishedfiledetails":[
+				{"publishedfileid":"100","result":1,"consumer_app_id":1281930,"file_size":"0","title":"Calamity Essentials","file_type":2},
 				{"publishedfileid":"200","result":1,"creator":"7656119","consumer_app_id":1281930,"file_size":"1024","preview_url":"https://steamusercontent.example/preview.png","title":"Calamity","description":"A mod","time_created":10,"time_updated":20,"file_type":0,"subscriptions":100,"favorited":4,"views":200,"tags":[{"tag":"New Content"}]},
 				{"publishedfileid":"201","result":1,"creator":"7656120","consumer_app_id":322330,"file_size":"2048","title":"Wrong game","file_type":0}
 			]}}`)
@@ -79,7 +80,7 @@ func TestSteamResolverExpandsCollectionAndFiltersAppID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if collection.ID != "100" || len(collection.Items) != 1 {
+	if collection.ID != "100" || collection.Title != "Calamity Essentials" || len(collection.Items) != 1 {
 		t.Fatalf("unexpected collection: %+v", collection)
 	}
 	item := collection.Items[0]

--- a/apps/api/internal/workshop/types.go
+++ b/apps/api/internal/workshop/types.go
@@ -25,6 +25,7 @@ type Resolver interface {
 
 type Collection struct {
 	ID    string `json:"collectionId"`
+	Title string `json:"title,omitempty"`
 	Items []Item `json:"items"`
 }
 

--- a/apps/web/app/mods/page.tsx
+++ b/apps/web/app/mods/page.tsx
@@ -141,7 +141,7 @@ export default function ModsPage() {
     onSuccess: (preview) => {
       setErrorMessage("");
       setPackCollectionPreview(preview);
-      setPackCollectionName((current) => current.trim() || t("steamCollectionDefaultPackName", { id: preview.collectionId }));
+      setPackCollectionName((current) => current.trim() || preview.collectionName?.trim() || t("steamCollectionDefaultPackName", { id: preview.collectionId }));
     },
     onError: (error) => {
       setPackCollectionPreview(null);
@@ -417,13 +417,13 @@ export default function ModsPage() {
             count={searchedModPacks.length}
             actions={(
               <div className="flex flex-wrap gap-2">
-                <Button variant="secondary" onClick={() => setPackImportDialogOpen(true)} disabled={workshopUnsupported} title={workshopUnsupported ? t("workshopArmUnsupported") : undefined}>
-                  <Download aria-hidden="true" />
-                  {t("importFromSteam")}
-                </Button>
                 <Button variant="secondary" onClick={() => setPackDialogOpen(true)}>
                   <Package aria-hidden="true" />
                   {t("createModPack")}
+                </Button>
+                <Button variant="secondary" onClick={() => setPackImportDialogOpen(true)} disabled={workshopUnsupported} title={workshopUnsupported ? t("workshopArmUnsupported") : undefined}>
+                  <Download aria-hidden="true" />
+                  {t("importFromSteam")}
                 </Button>
               </div>
             )}
@@ -762,7 +762,7 @@ export default function ModsPage() {
             <div>
               <div className="flex flex-wrap items-start justify-between gap-3 border-b border-panel-line pb-3">
                 <div>
-                  <p className="font-medium text-slate-100">{t("steamCollectionNumber", { id: packCollectionPreview.collectionId })}</p>
+                  <p className="font-medium text-slate-100">{packCollectionPreview.collectionName || t("steamCollectionNumber", { id: packCollectionPreview.collectionId })}</p>
                   <p className="mt-1 text-xs text-slate-500">
                     {t("workshopPreviewSummary", {
                       total: packCollectionPreview.summary.total,

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -370,6 +370,7 @@ export type WorkshopPreviewItem = {
 export type WorkshopPreview = {
   previewId: string;
   collectionId: string;
+  collectionName?: string;
   providerKey: ProviderKey;
   expiresAt: string;
   items: WorkshopPreviewItem[];


### PR DESCRIPTION
## Summary
- fetch and return the original Steam Workshop collection title
- use the collection title as the default imported mod pack name
- keep Steam import as the rightmost mod pack action

## Validation
- go test ./apps/api/internal/workshop ./apps/api/internal/http
- pnpm --dir apps/web lint
- pnpm --dir apps/web build