### PR TITLE
fix: resolve Steam collection page titles

### DIFF
--- a/apps/api/internal/workshop/steam.go
+++ b/apps/api/internal/workshop/steam.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"html"
 	"io"
 	"net/http"
 	"net/url"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -16,18 +18,24 @@ import (
 )
 
 const (
-	defaultSteamAPIBase = "https://api.steampowered.com"
-	maxSteamResponse    = 4 << 20
-	steamBatchSize      = 50
+	defaultSteamAPIBase       = "https://api.steampowered.com"
+	defaultSteamCommunityBase = "https://steamcommunity.com"
+	maxSteamResponse          = 4 << 20
+	steamBatchSize            = 50
 )
 
 type SteamResolver struct {
-	client  *http.Client
-	apiBase string
+	client        *http.Client
+	apiBase       string
+	communityBase string
 }
 
+var workshopItemTitlePattern = regexp.MustCompile(`(?is)<div\s+class=["']workshopItemTitle["']\s*>\s*([^<]+?)\s*</div>`)
+
 func NewSteamResolver() *SteamResolver {
-	return NewSteamResolverWithClient(&http.Client{Timeout: 10 * time.Second}, defaultSteamAPIBase)
+	resolver := NewSteamResolverWithClient(&http.Client{Timeout: 10 * time.Second}, defaultSteamAPIBase)
+	resolver.communityBase = defaultSteamCommunityBase
+	return resolver
 }
 
 func NewSteamResolverWithClient(client *http.Client, apiBase string) *SteamResolver {
@@ -35,8 +43,9 @@ func NewSteamResolverWithClient(client *http.Client, apiBase string) *SteamResol
 		client = &http.Client{Timeout: 10 * time.Second}
 	}
 	return &SteamResolver{
-		client:  client,
-		apiBase: strings.TrimRight(apiBase, "/"),
+		client:        client,
+		apiBase:       strings.TrimRight(apiBase, "/"),
+		communityBase: strings.TrimRight(apiBase, "/"),
 	}
 }
 
@@ -66,7 +75,40 @@ func (r *SteamResolver) ResolveCollection(ctx context.Context, providerKey domai
 	if len(items) == 0 {
 		return Collection{}, fmt.Errorf("%w: collection has no compatible items", ErrInvalidCollection)
 	}
+	if title == "" {
+		title, _ = r.collectionPageTitle(ctx, collectionID)
+	}
 	return Collection{ID: collectionID, Title: title, Items: items}, nil
+}
+
+func (r *SteamResolver) collectionPageTitle(ctx context.Context, collectionID string) (string, error) {
+	requestURL := r.communityBase + "/sharedfiles/filedetails/?id=" + url.QueryEscape(collectionID)
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+	if err != nil {
+		return "", err
+	}
+	request.Header.Set("User-Agent", "GamePanel-Lite/1.0")
+	response, err := r.client.Do(request)
+	if err != nil {
+		return "", fmt.Errorf("Steam Workshop page request failed: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("Steam Workshop page returned HTTP %d", response.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, maxSteamResponse))
+	if err != nil {
+		return "", err
+	}
+	match := workshopItemTitlePattern.FindSubmatch(body)
+	if len(match) != 2 {
+		return "", fmt.Errorf("Steam Workshop collection title was not found")
+	}
+	title := truncateRunes(strings.TrimSpace(html.UnescapeString(string(match[1]))), 300)
+	if title == "" {
+		return "", fmt.Errorf("Steam Workshop collection title was empty")
+	}
+	return title, nil
 }
 
 func ParseCollectionID(input string) (string, error) {

--- a/apps/api/internal/workshop/steam_test.go
+++ b/apps/api/internal/workshop/steam_test.go
@@ -49,6 +49,11 @@ func TestSteamResolverExpandsCollectionAndFiltersAppID(t *testing.T) {
 			t.Fatal(err)
 		}
 		switch r.URL.Path {
+		case "/sharedfiles/filedetails/":
+			if r.Form.Get("id") != "100" {
+				t.Fatalf("unexpected collection page id %q", r.Form.Get("id"))
+			}
+			fmt.Fprint(w, `<html><div class="workshopItemTitle">Calamity &amp; Friends</div></html>`)
 		case "/ISteamRemoteStorage/GetCollectionDetails/v1/":
 			id := r.Form.Get("publishedfileids[0]")
 			if id == "100" {
@@ -65,7 +70,7 @@ func TestSteamResolverExpandsCollectionAndFiltersAppID(t *testing.T) {
 				t.Fatalf("unexpected itemcount %q", r.Form.Get("itemcount"))
 			}
 			fmt.Fprint(w, `{"response":{"publishedfiledetails":[
-				{"publishedfileid":"100","result":1,"consumer_app_id":1281930,"file_size":"0","title":"Calamity Essentials","file_type":2},
+				{"publishedfileid":"100","result":9,"consumer_app_id":1281930,"file_size":"0","file_type":2},
 				{"publishedfileid":"200","result":1,"creator":"7656119","consumer_app_id":1281930,"file_size":"1024","preview_url":"https://steamusercontent.example/preview.png","title":"Calamity","description":"A mod","time_created":10,"time_updated":20,"file_type":0,"subscriptions":100,"favorited":4,"views":200,"tags":[{"tag":"New Content"}]},
 				{"publishedfileid":"201","result":1,"creator":"7656120","consumer_app_id":322330,"file_size":"2048","title":"Wrong game","file_type":0}
 			]}}`)
@@ -80,7 +85,7 @@ func TestSteamResolverExpandsCollectionAndFiltersAppID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if collection.ID != "100" || collection.Title != "Calamity Essentials" || len(collection.Items) != 1 {
+	if collection.ID != "100" || collection.Title != "Calamity & Friends" || len(collection.Items) != 1 {
 		t.Fatalf("unexpected collection: %+v", collection)
 	}
 	item := collection.Items[0]


### PR DESCRIPTION
## Summary
- fall back to the public Steam Workshop collection page when the API omits collection titles
- decode and bound the public collection title before returning it
- cover the HTML title fallback with resolver tests

## Validation
- go test ./apps/api/internal/workshop ./apps/api/internal/http