### PR TITLE
添加脚本指定安装路径的写法，修复没有正确挂载ModConfigs文件夹的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,10 @@ Run this on a server with Docker installed:
 curl -fsSL https://raw.githubusercontent.com/smartcat999/game-panel-lite/main/scripts/install-online.sh | sh
 
 # Or specify a custom install path:
-curl -fsSL https://raw.githubusercontent.com/smartcat999/game-panel-lite/main/scripts/install-online.sh | sh -s -- /opt/gamepanel-lite
+curl -fsSL https://raw.githubusercontent.com/smartcat999/game-panel-lite/main/scripts/install-online.sh | sh -s -- "$HOME/apps/gamepanel-lite"
 ```
+
+The target directory must be writable by the current user. Use elevated permissions only when installing into a system directory such as `/opt`.
 
 Then open:
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ Running a game server should not mean juggling shell commands, scattered config 
 Run this on a server with Docker installed:
 
 ```bash
+# Default: installs to ~/gamepanel-lite
 curl -fsSL https://raw.githubusercontent.com/smartcat999/game-panel-lite/main/scripts/install-online.sh | sh
+
+# Or specify a custom install path:
+curl -fsSL https://raw.githubusercontent.com/smartcat999/game-panel-lite/main/scripts/install-online.sh | sh -s -- /opt/gamepanel-lite
 ```
 
 Then open:

--- a/apps/api/internal/provider/terraria/config_test.go
+++ b/apps/api/internal/provider/terraria/config_test.go
@@ -130,6 +130,16 @@ func TestTModLoaderRuntimeOptionsUseNonInteractiveConfig(t *testing.T) {
 			t.Fatalf("expected tModLoader env to contain %q, got:\n%s", expected, env)
 		}
 	}
+	foundModConfigsMount := false
+	for _, mount := range options.DataMounts {
+		if mount == "ModConfigs:/home/container/ModConfigs" {
+			foundModConfigsMount = true
+			break
+		}
+	}
+	if !foundModConfigsMount {
+		t.Fatalf("expected tModLoader runtime to persist ModConfigs, got: %v", options.DataMounts)
+	}
 	rendered := options.Files["serverconfig.txt"]
 	for _, expected := range []string{
 		"world=/home/container/Worlds/Modded Smoke.wld",

--- a/apps/api/internal/provider/terraria/provider.go
+++ b/apps/api/internal/provider/terraria/provider.go
@@ -465,6 +465,7 @@ func tModLoaderRuntimeOptions(config Config) runtime.ContainerOptions {
 		DataMounts: []string{
 			"Worlds:/home/container/Worlds",
 			"Mods:/home/container/Mods",
+			"ModConfigs:/home/container/ModConfigs",
 			"logs:/home/container/logs",
 			"steamapps:/home/container/steamapps",
 			"serverconfig.txt:/home/container/serverconfig.txt",

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -34,8 +34,10 @@ GamePanel Lite 是一个轻量、现代、可自托管的游戏服务器管理�
 curl -fsSL https://raw.githubusercontent.com/smartcat999/game-panel-lite/main/scripts/install-online.sh | sh
 
 # 或指定自定义安装路径：
-curl -fsSL https://raw.githubusercontent.com/smartcat999/game-panel-lite/main/scripts/install-online.sh | sh -s -- /opt/gamepanel-lite
+curl -fsSL https://raw.githubusercontent.com/smartcat999/game-panel-lite/main/scripts/install-online.sh | sh -s -- "$HOME/apps/gamepanel-lite"
 ```
+
+目标目录必须允许当前用户写入。只有安装到 `/opt` 等系统目录时才需要使用提升后的权限。
 
 启动完成后访问：
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -30,7 +30,11 @@ GamePanel Lite 是一个轻量、现代、可自托管的游戏服务器管理�
 准备一台已经安装 Docker 的服务器，然后运行：
 
 ```bash
+# 默认安装到 ~/gamepanel-lite
 curl -fsSL https://raw.githubusercontent.com/smartcat999/game-panel-lite/main/scripts/install-online.sh | sh
+
+# 或指定自定义安装路径：
+curl -fsSL https://raw.githubusercontent.com/smartcat999/game-panel-lite/main/scripts/install-online.sh | sh -s -- /opt/gamepanel-lite
 ```
 
 启动完成后访问：

--- a/scripts/install-online.sh
+++ b/scripts/install-online.sh
@@ -2,7 +2,11 @@
 set -eu
 
 REPO_ARCHIVE_URL="${GAMEPANEL_ARCHIVE_URL:-https://github.com/smartcat999/game-panel-lite/archive/refs/heads/main.tar.gz}"
-INSTALL_DIR="${GAMEPANEL_INSTALL_DIR:-$HOME/gamepanel-lite}"
+if [ -n "${1:-}" ]; then
+  INSTALL_DIR="$1"
+else
+  INSTALL_DIR="${GAMEPANEL_INSTALL_DIR:-$HOME/gamepanel-lite}"
+fi
 
 if ! command -v curl >/dev/null 2>&1; then
   echo "curl is required. Install curl first, then run this command again."


### PR DESCRIPTION
针对 https://github.com/smartcat999/game-panel-lite/issues/61 的改动

但实际上，需要在前端页面中支持ModConfigs的修改。
这是一个新feature，需要进一步评估。