### PR TITLE
fix: share game version checks by provider

### DIFF
--- a/apps/api/internal/domain/models.go
+++ b/apps/api/internal/domain/models.go
@@ -101,6 +101,17 @@ type ProviderCatalog struct {
 	ConfigSchema       []ProviderConfigField `json:"configSchema"`
 	SaveDisplayName    string                `json:"saveDisplayName,omitempty"`
 	RuntimeImage       RuntimeImageStatus    `json:"runtimeImage,omitempty"`
+	GameVersion        ProviderVersionStatus `json:"gameVersion,omitempty"`
+}
+
+type ProviderVersionStatus struct {
+	Supported        bool           `json:"supported"`
+	Status           string         `json:"status"`
+	LatestBuildID    string         `json:"latestBuildId,omitempty"`
+	CheckedAt        *time.Time     `json:"checkedAt,omitempty"`
+	AutoCheckEnabled bool           `json:"autoCheckEnabled"`
+	AutoCheckHours   int            `json:"autoCheckIntervalHours"`
+	Job              *GameUpdateJob `json:"job,omitempty"`
 }
 
 const (

--- a/apps/api/internal/http/game_handlers.go
+++ b/apps/api/internal/http/game_handlers.go
@@ -14,6 +14,7 @@ func (h *Handler) listGames(w http.ResponseWriter, r *http.Request) {
 	games := h.provider.Games()
 	h.applyRuntimeGameAvailability(games)
 	h.attachRuntimeImageStatuses(r.Context(), games)
+	h.attachProviderVersionStatuses(r.Context(), games)
 	servers, err := h.store.ListGameServers(r.Context())
 	if err == nil {
 		counts := map[domain.GameKey]int{}
@@ -36,7 +37,37 @@ func (h *Handler) getGame(w http.ResponseWriter, r *http.Request) {
 	games := []domain.GameCatalogEntry{game}
 	h.applyRuntimeGameAvailability(games)
 	h.attachRuntimeImageStatuses(r.Context(), games)
+	h.attachProviderVersionStatuses(r.Context(), games)
 	writeJSON(w, http.StatusOK, games[0])
+}
+
+func (h *Handler) attachProviderVersionStatuses(ctx context.Context, games []domain.GameCatalogEntry) {
+	for gameIndex := range games {
+		for providerIndex := range games[gameIndex].Providers {
+			item := &games[gameIndex].Providers[providerIndex]
+			item.GameVersion = domain.ProviderVersionStatus{Status: "unsupported"}
+			if item.Key != domain.ProviderPalworld {
+				continue
+			}
+			item.GameVersion = domain.ProviderVersionStatus{Supported: true, Status: "unknown", AutoCheckEnabled: true, AutoCheckHours: int(gameUpdateAutoCheckInterval / time.Hour)}
+			if enabled, err := h.gameUpdateAutoCheckEnabled(ctx, item.Key); err == nil {
+				item.GameVersion.AutoCheckEnabled = enabled
+			}
+			job, err := h.store.GetLatestGameUpdateCheckByProvider(ctx, item.Key)
+			if err != nil {
+				continue
+			}
+			item.GameVersion.Job, item.GameVersion.LatestBuildID, item.GameVersion.CheckedAt = &job, job.LatestBuildID, job.CheckedAt
+			switch job.Status {
+			case domain.GameUpdateJobQueued, domain.GameUpdateJobRunning:
+				item.GameVersion.Status = "checking"
+			case domain.GameUpdateJobFailed:
+				item.GameVersion.Status = "failed"
+			default:
+				item.GameVersion.Status = "ready"
+			}
+		}
+	}
 }
 
 func (h *Handler) applyRuntimeGameAvailability(games []domain.GameCatalogEntry) {

--- a/apps/api/internal/http/game_update_handlers.go
+++ b/apps/api/internal/http/game_update_handlers.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sync"
 	"syscall"
 	"time"
@@ -35,6 +36,8 @@ const (
 	minGameUpdateFreeDiskBytes   = int64(8 * 1024 * 1024 * 1024)
 	minGameUpdateFreeMemoryMB    = int64(2560)
 )
+
+var steamManifestBuildPattern = regexp.MustCompile(`(?m)^\s*"buildid"\s*"([0-9]+)"\s*$`)
 
 type gameUpdateView struct {
 	Supported        bool                  `json:"supported"`
@@ -63,12 +66,16 @@ func (h *Handler) getGameUpdate(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, view)
 		return
 	}
-	view.AutoCheckEnabled, err = h.gameUpdateAutoCheckEnabled(r.Context(), server.ID)
+	view.AutoCheckEnabled, err = h.gameUpdateAutoCheckEnabled(r.Context(), server.ProviderKey)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	job, err := h.store.GetLatestGameUpdateJobByInstance(r.Context(), server.ID)
+	installedBuildID, installedErr := installedServerBuildID(server, palworldSteamAppID)
+	if installedErr == nil {
+		view.InstalledBuildID = installedBuildID
+	}
+	providerCheck, err := h.store.GetLatestGameUpdateCheckByProvider(r.Context(), server.ProviderKey)
 	if errors.Is(err, store.ErrNotFound) {
 		writeJSON(w, http.StatusOK, view)
 		return
@@ -77,8 +84,11 @@ func (h *Handler) getGameUpdate(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	view.Job, view.InstalledBuildID, view.LatestBuildID = &job, job.InstalledBuildID, job.LatestBuildID
-	view.CheckedAt = job.CheckedAt
+	view.Job, view.LatestBuildID, view.CheckedAt = &providerCheck, providerCheck.LatestBuildID, providerCheck.CheckedAt
+	if instanceJob, instanceErr := h.store.GetLatestGameUpdateJobByInstance(r.Context(), server.ID); instanceErr == nil && instanceJob.Operation == domain.GameUpdateOperationApply && (instanceJob.Status == domain.GameUpdateJobQueued || instanceJob.Status == domain.GameUpdateJobRunning) {
+		view.Job = &instanceJob
+	}
+	job := *view.Job
 	switch job.Status {
 	case domain.GameUpdateJobQueued, domain.GameUpdateJobRunning:
 		if job.Operation == domain.GameUpdateOperationCheck || (job.Operation == "" && job.Stage == domain.GameUpdateStageRefreshingMetadata) {
@@ -89,7 +99,7 @@ func (h *Handler) getGameUpdate(w http.ResponseWriter, r *http.Request) {
 	case domain.GameUpdateJobFailed:
 		view.Status = "failed"
 	default:
-		if job.LatestBuildID != "" && job.InstalledBuildID != job.LatestBuildID {
+		if view.LatestBuildID != "" && view.InstalledBuildID != view.LatestBuildID {
 			view.Status = "available"
 		} else {
 			view.Status = "up_to_date"
@@ -115,7 +125,7 @@ func (h *Handler) updateGameUpdateAutoCheck(w http.ResponseWriter, r *http.Reque
 		writeError(w, http.StatusBadRequest, "enabled must be a boolean")
 		return
 	}
-	if err := h.store.SetSetting(r.Context(), gameUpdateAutoCheckSettingKey(server.ID), fmt.Sprintf("%t", *payload.Enabled)); err != nil {
+	if err := h.store.SetSetting(r.Context(), gameUpdateAutoCheckSettingKey(server.ProviderKey), fmt.Sprintf("%t", *payload.Enabled)); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -126,6 +136,27 @@ func (h *Handler) updateGameUpdateAutoCheck(w http.ResponseWriter, r *http.Reque
 	})
 }
 
+func (h *Handler) updateProviderGameUpdateAutoCheck(w http.ResponseWriter, r *http.Request) {
+	providerKey := domain.ProviderKey(chi.URLParam(r, "providerKey"))
+	if providerKey != domain.ProviderPalworld {
+		writeError(w, http.StatusBadRequest, "automatic game update checks are not supported for this provider")
+		return
+	}
+	var payload struct {
+		Enabled *bool `json:"enabled"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil || payload.Enabled == nil {
+		writeError(w, http.StatusBadRequest, "enabled must be a boolean")
+		return
+	}
+	if err := h.store.SetSetting(r.Context(), gameUpdateAutoCheckSettingKey(providerKey), fmt.Sprintf("%t", *payload.Enabled)); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	h.recordActivity(r.Context(), "", "provider.game-update.auto-check", "Updated automatic game version checks for "+string(providerKey), map[string]any{"enabled": *payload.Enabled, "providerKey": providerKey})
+	writeJSON(w, http.StatusOK, map[string]any{"enabled": *payload.Enabled, "intervalHours": int(gameUpdateAutoCheckInterval / time.Hour)})
+}
+
 func (h *Handler) checkGameUpdate(w http.ResponseWriter, r *http.Request) {
 	unlock := h.lockServerMutation(chi.URLParam(r, "id"))
 	defer unlock()
@@ -133,20 +164,38 @@ func (h *Handler) checkGameUpdate(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	job, ok := h.newGameUpdateJob(w, r, server, domain.GameUpdateOperationCheck, false, false, domain.GameUpdateStageRefreshingMetadata)
+	job, ok := h.newProviderGameUpdateCheckJob(w, r, server.ProviderKey)
 	if !ok {
 		return
 	}
-	h.startGameUpdateWorker(func() { h.runGameUpdateCheck(h.backgroundContext(), server, job) })
+	h.startGameUpdateWorker(func() { h.runGameUpdateCheck(h.backgroundContext(), server.ProviderKey, job) })
 	writeJSON(w, http.StatusAccepted, job)
 }
 
-func gameUpdateAutoCheckSettingKey(instanceID string) string {
-	return "gameUpdate.autoCheck." + instanceID
+func (h *Handler) checkProviderGameUpdate(w http.ResponseWriter, r *http.Request) {
+	providerKey := domain.ProviderKey(chi.URLParam(r, "providerKey"))
+	if providerKey != domain.ProviderPalworld {
+		writeError(w, http.StatusBadRequest, "game version checks are not supported for this provider")
+		return
+	}
+	if err := h.requireRuntimeAvailable(r.Context()); err != nil || !h.runtime.SupportsGameUpdates() {
+		writeError(w, http.StatusServiceUnavailable, "runtime adapter does not support game version checks")
+		return
+	}
+	job, ok := h.newProviderGameUpdateCheckJob(w, r, providerKey)
+	if !ok {
+		return
+	}
+	h.startGameUpdateWorker(func() { h.runGameUpdateCheck(h.backgroundContext(), providerKey, job) })
+	writeJSON(w, http.StatusAccepted, job)
 }
 
-func (h *Handler) gameUpdateAutoCheckEnabled(ctx context.Context, instanceID string) (bool, error) {
-	value, err := h.store.GetSetting(ctx, gameUpdateAutoCheckSettingKey(instanceID))
+func gameUpdateAutoCheckSettingKey(providerKey domain.ProviderKey) string {
+	return "gameUpdate.autoCheck.provider." + string(providerKey)
+}
+
+func (h *Handler) gameUpdateAutoCheckEnabled(ctx context.Context, providerKey domain.ProviderKey) (bool, error) {
+	value, err := h.store.GetSetting(ctx, gameUpdateAutoCheckSettingKey(providerKey))
 	if err != nil {
 		return false, err
 	}
@@ -193,22 +242,15 @@ func (h *Handler) scanAutomaticGameUpdateChecks(ctx context.Context, now time.Ti
 	if len(worldJobs) > 0 {
 		return nil
 	}
-	servers, err := h.store.ListGameServers(ctx)
-	if err != nil {
-		return err
-	}
-	for _, server := range servers {
-		if server.ProviderKey != domain.ProviderPalworld {
-			continue
-		}
-		enabled, err := h.gameUpdateAutoCheckEnabled(ctx, server.ID)
+	for _, providerKey := range []domain.ProviderKey{domain.ProviderPalworld} {
+		enabled, err := h.gameUpdateAutoCheckEnabled(ctx, providerKey)
 		if err != nil {
 			return err
 		}
 		if !enabled {
 			continue
 		}
-		previous, err := h.store.GetLatestGameUpdateJobByInstance(ctx, server.ID)
+		previous, err := h.store.GetLatestGameUpdateCheckByProvider(ctx, providerKey)
 		if err != nil && !errors.Is(err, store.ErrNotFound) {
 			return err
 		}
@@ -223,8 +265,8 @@ func (h *Handler) scanAutomaticGameUpdateChecks(ctx context.Context, now time.Ti
 		}
 		job := domain.GameUpdateJob{
 			ID:          uuid.NewString(),
-			InstanceID:  server.ID,
-			ProviderKey: server.ProviderKey,
+			InstanceID:  providerGameUpdateScope(providerKey),
+			ProviderKey: providerKey,
 			Operation:   domain.GameUpdateOperationCheck,
 			Status:      domain.GameUpdateJobQueued,
 			Stage:       domain.GameUpdateStageRefreshingMetadata,
@@ -248,11 +290,49 @@ func (h *Handler) scanAutomaticGameUpdateChecks(ctx context.Context, now time.Ti
 		if len(active) > 0 {
 			return nil
 		}
-		h.recordActivity(ctx, server.ID, "server.game-update.auto-check.queued", "Queued automatic game update check for "+server.Name, map[string]any{"jobId": job.ID})
-		h.startGameUpdateWorker(func() { h.runGameUpdateCheck(h.backgroundContext(), server, job) })
+		h.recordActivity(ctx, "", "provider.game-update.auto-check.queued", "Queued automatic game version check for "+string(providerKey), map[string]any{"jobId": job.ID, "providerKey": providerKey})
+		h.startGameUpdateWorker(func() { h.runGameUpdateCheck(h.backgroundContext(), providerKey, job) })
 		return nil
 	}
 	return nil
+}
+
+func providerGameUpdateScope(providerKey domain.ProviderKey) string {
+	return "provider:" + string(providerKey)
+}
+
+func (h *Handler) newProviderGameUpdateCheckJob(w http.ResponseWriter, r *http.Request, providerKey domain.ProviderKey) (domain.GameUpdateJob, bool) {
+	h.gameUpdateJobsMu.Lock()
+	defer h.gameUpdateJobsMu.Unlock()
+	activeJobs, err := h.store.ListActiveGameUpdateJobs(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return domain.GameUpdateJob{}, false
+	}
+	for _, active := range activeJobs {
+		if active.ProviderKey == providerKey && active.Operation == domain.GameUpdateOperationCheck {
+			writeError(w, http.StatusConflict, "a game version check is already running for this provider")
+			return domain.GameUpdateJob{}, false
+		}
+	}
+	if len(activeJobs) > 0 || h.runtimeImagePrepareActive() {
+		writeError(w, http.StatusConflict, "another game update task is already running")
+		return domain.GameUpdateJob{}, false
+	}
+	now := time.Now().UTC()
+	job := domain.GameUpdateJob{ID: uuid.NewString(), InstanceID: providerGameUpdateScope(providerKey), ProviderKey: providerKey, Operation: domain.GameUpdateOperationCheck, Status: domain.GameUpdateJobQueued, Stage: domain.GameUpdateStageRefreshingMetadata, CreatedAt: now, UpdatedAt: now}
+	if previous, previousErr := h.store.GetLatestGameUpdateCheckByProvider(r.Context(), providerKey); previousErr == nil {
+		job.LatestBuildID, job.CheckedAt = previous.LatestBuildID, previous.CheckedAt
+	} else if !errors.Is(previousErr, store.ErrNotFound) {
+		writeError(w, http.StatusInternalServerError, previousErr.Error())
+		return domain.GameUpdateJob{}, false
+	}
+	if err := h.store.CreateGameUpdateJob(r.Context(), &job); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return domain.GameUpdateJob{}, false
+	}
+	h.recordActivity(r.Context(), "", "provider.game-update.queued", "Queued game version check for "+string(providerKey), map[string]any{"jobId": job.ID, "providerKey": providerKey})
+	return job, true
 }
 
 func (h *Handler) applyGameUpdate(w http.ResponseWriter, r *http.Request) {
@@ -353,24 +433,58 @@ func (h *Handler) newGameUpdateJob(w http.ResponseWriter, r *http.Request, serve
 	return job, true
 }
 
-func (h *Handler) runGameUpdateCheck(ctx context.Context, server domain.GameServer, job domain.GameUpdateJob) {
+func (h *Handler) runGameUpdateCheck(ctx context.Context, providerKey domain.ProviderKey, job domain.GameUpdateJob) {
 	ctx, cancel := context.WithTimeout(ctx, gameUpdateCheckTimeout)
 	defer cancel()
 	h.updateGameJob(&job, domain.GameUpdateJobRunning, domain.GameUpdateStageRefreshingMetadata, 10, "")
-	request, err := h.gameUpdateRequest(server, job.ID)
+	request, err := h.providerGameUpdateCheckRequest(providerKey, job.ID)
 	if err != nil {
 		h.failGameJob(&job, err)
 		return
 	}
 	result, err := h.runtime.CheckGameUpdate(ctx, request)
 	if err != nil {
-		h.failGameUpdateTask(ctx, server, &job, err, false)
+		h.failGameJob(&job, err)
 		return
 	}
-	job.InstalledBuildID, job.LatestBuildID = result.InstalledBuildID, result.LatestBuildID
+	job.LatestBuildID = result.LatestBuildID
 	checkedAt := time.Now().UTC()
 	job.CheckedAt = &checkedAt
 	h.completeGameJob(&job)
+}
+
+func (h *Handler) providerGameUpdateCheckRequest(providerKey domain.ProviderKey, jobID string) (runtime.GameUpdateRequest, error) {
+	gameProvider, ok := h.provider.Get(providerKey)
+	if !ok {
+		return runtime.GameUpdateRequest{}, fmt.Errorf("provider %s is unavailable", providerKey)
+	}
+	appID := ""
+	switch providerKey {
+	case domain.ProviderPalworld:
+		appID = palworldSteamAppID
+	default:
+		return runtime.GameUpdateRequest{}, fmt.Errorf("game version checks are not implemented for provider %s", providerKey)
+	}
+	return runtime.GameUpdateRequest{JobID: jobID, RuntimeID: providerGameUpdateScope(providerKey), Image: gameProvider.Image(), AppID: appID}, nil
+}
+
+func installedServerBuildID(server domain.GameServer, appID string) (string, error) {
+	dataDir, err := serverDataDir(server)
+	if err != nil {
+		return "", err
+	}
+	content, err := os.ReadFile(filepath.Join(dataDir, "steamapps", "appmanifest_"+appID+".acf"))
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("read installed Steam manifest: %w", err)
+	}
+	match := steamManifestBuildPattern.FindStringSubmatch(string(content))
+	if len(match) != 2 {
+		return "", fmt.Errorf("buildid was not found in installed Steam manifest")
+	}
+	return match[1], nil
 }
 
 func (h *Handler) runGameUpdateApply(ctx context.Context, server domain.GameServer, job domain.GameUpdateJob) {
@@ -626,12 +740,20 @@ func (h *Handler) failGameJob(job *domain.GameUpdateJob, err error) {
 	now := time.Now().UTC()
 	job.CompletedAt = &now
 	h.updateTerminalGameJob(job, domain.GameUpdateJobFailed, job.Stage, job.Progress, err.Error())
+	if job.Operation == domain.GameUpdateOperationCheck {
+		h.recordActivity(context.Background(), "", "provider.game-update.failed", err.Error(), map[string]any{"jobId": job.ID, "providerKey": job.ProviderKey})
+		return
+	}
 	h.recordActivity(context.Background(), job.InstanceID, "server.game-update.failed", err.Error(), map[string]any{"jobId": job.ID})
 }
 func (h *Handler) completeGameJob(job *domain.GameUpdateJob) {
 	now := time.Now().UTC()
 	job.CompletedAt = &now
 	h.updateTerminalGameJob(job, domain.GameUpdateJobSucceeded, domain.GameUpdateStageCompleted, 100, "")
+	if job.Operation == domain.GameUpdateOperationCheck {
+		h.recordActivity(context.Background(), "", "provider.game-update.succeeded", "Game version check completed", map[string]any{"jobId": job.ID, "providerKey": job.ProviderKey, "buildId": job.LatestBuildID})
+		return
+	}
 	h.recordActivity(context.Background(), job.InstanceID, "server.game-update.succeeded", "Game update task completed", map[string]any{"jobId": job.ID, "buildId": job.InstalledBuildID})
 }
 

--- a/apps/api/internal/http/game_update_handlers_test.go
+++ b/apps/api/internal/http/game_update_handlers_test.go
@@ -15,6 +15,8 @@ import (
 	"time"
 
 	"github.com/smartcat999/game-panel-lite/apps/api/internal/domain"
+	"github.com/smartcat999/game-panel-lite/apps/api/internal/provider"
+	"github.com/smartcat999/game-panel-lite/apps/api/internal/provider/palworld"
 	"github.com/smartcat999/game-panel-lite/apps/api/internal/runtime"
 	"github.com/smartcat999/game-panel-lite/apps/api/internal/store"
 )
@@ -171,38 +173,17 @@ func TestGameUpdateAutoCheckDefaultsOnAndCanBeDisabled(t *testing.T) {
 	}
 }
 
-func TestAutomaticGameUpdateScanQueuesOnlyStaleEnabledServer(t *testing.T) {
+func TestAutomaticGameUpdateScanQueuesOneStaleProviderCheck(t *testing.T) {
 	adapter := newGameUpdateHTTPAdapter()
 	t.Cleanup(adapter.releaseCheck)
-	handler, db, dataDir := newGameUpdateUnitHandler(t, adapter)
+	handler, db, _ := newGameUpdateUnitHandler(t, adapter)
 	handler.ctx = context.Background()
-	disabled := palworldUpdateTestServer("palworld-auto-disabled", dataDir)
-	disabled.CreatedAt = time.Now().Add(time.Minute)
-	createTestServer(t, db, disabled)
-	if err := db.SetSetting(context.Background(), gameUpdateAutoCheckSettingKey(disabled.ID), "false"); err != nil {
-		t.Fatal(err)
-	}
-	fresh := palworldUpdateTestServer("palworld-auto-fresh", dataDir)
-	fresh.CreatedAt = time.Now().Add(2 * time.Minute)
-	createTestServer(t, db, fresh)
 	checkedAt := time.Now().UTC()
 	if err := db.CreateGameUpdateJob(context.Background(), &domain.GameUpdateJob{
-		ID: "fresh-check", InstanceID: fresh.ID, ProviderKey: domain.ProviderPalworld,
+		ID: "stale-provider-check", InstanceID: providerGameUpdateScope(domain.ProviderPalworld), ProviderKey: domain.ProviderPalworld,
 		Operation: domain.GameUpdateOperationCheck, Status: domain.GameUpdateJobSucceeded,
-		Stage: domain.GameUpdateStageCompleted, CheckedAt: &checkedAt, CreatedAt: checkedAt, UpdatedAt: checkedAt,
+		Stage: domain.GameUpdateStageCompleted, CheckedAt: &checkedAt, CreatedAt: checkedAt, UpdatedAt: checkedAt, LatestBuildID: "24000000",
 	}); err != nil {
-		t.Fatal(err)
-	}
-	due := palworldUpdateTestServer("palworld-auto-due", dataDir)
-	due.CreatedAt = time.Now().Add(3 * time.Minute)
-	due.ContainerID = "palworld-auto-runtime"
-	createTestServer(t, db, due)
-	dueResource, err := db.GetGameServer(context.Background(), due.ID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	dueResource.Spec.Runtime.Image = "smartcat99999/palworld-server:v2.7.1"
-	if err := db.SaveGameServer(context.Background(), &dueResource); err != nil {
 		t.Fatal(err)
 	}
 
@@ -213,22 +194,19 @@ func TestAutomaticGameUpdateScanQueuesOnlyStaleEnabledServer(t *testing.T) {
 	select {
 	case request = <-adapter.checkStarted:
 	case <-time.After(time.Second):
-		t.Fatal("expected stale enabled server to start an automatic check")
+		t.Fatal("expected stale provider to start an automatic check")
 	}
-	if request.RuntimeID != due.ContainerID {
-		t.Fatalf("expected due server runtime %q, got %+v", due.ContainerID, request)
+	if request.RuntimeID != providerGameUpdateScope(domain.ProviderPalworld) || request.DataDir != "" {
+		t.Fatalf("expected provider-scoped request without a server data directory, got %+v", request)
 	}
 	adapter.releaseCheck()
 	active := waitForGameUpdateJobStatus(t, db, request.JobID, domain.GameUpdateJobSucceeded)
 	if active.Operation != domain.GameUpdateOperationCheck {
 		t.Fatalf("expected automatic check operation, got %+v", active)
 	}
-	if _, err := db.GetLatestGameUpdateJobByInstance(context.Background(), disabled.ID); !errors.Is(err, store.ErrNotFound) {
-		t.Fatalf("expected disabled server to remain unchecked, got %v", err)
-	}
-	latestFresh, err := db.GetLatestGameUpdateJobByInstance(context.Background(), fresh.ID)
-	if err != nil || latestFresh.ID != "fresh-check" {
-		t.Fatalf("expected fresh check to remain latest, got %+v err=%v", latestFresh, err)
+	latest, err := db.GetLatestGameUpdateCheckByProvider(context.Background(), domain.ProviderPalworld)
+	if err != nil || latest.ID != active.ID {
+		t.Fatalf("expected shared provider check to be latest, got %+v err=%v", latest, err)
 	}
 }
 
@@ -259,14 +237,14 @@ func TestCheckGameUpdateReturnsAcceptedAndPersistsResult(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("expected async update check to reach the runtime adapter")
 	}
-	if request.JobID != queued.ID || request.AppID != palworldSteamAppID || request.RuntimeID != server.ContainerID || request.DataDir != server.DataDir {
+	if request.JobID != queued.ID || request.AppID != palworldSteamAppID || request.RuntimeID != providerGameUpdateScope(domain.ProviderPalworld) || request.DataDir != "" {
 		t.Fatalf("unexpected update request: %+v", request)
 	}
 	adapter.releaseCheck()
 
 	completed := waitForGameUpdateJobStatus(t, db, queued.ID, domain.GameUpdateJobSucceeded)
-	if completed.InstalledBuildID != "24088465" || completed.LatestBuildID != "24181105" {
-		t.Fatalf("expected persisted build ids, got %+v", completed)
+	if completed.InstalledBuildID != "" || completed.LatestBuildID != "24181105" {
+		t.Fatalf("expected provider check to persist only the latest build id, got %+v", completed)
 	}
 	if completed.Stage != domain.GameUpdateStageCompleted || completed.Progress != 100 || completed.CheckedAt == nil || completed.CompletedAt == nil {
 		t.Fatalf("expected completed job metadata, got %+v", completed)
@@ -752,6 +730,7 @@ func newGameUpdateUnitHandler(t *testing.T, adapter runtime.Adapter) (*Handler, 
 	dataDir := filepath.Join(root, "data")
 	return &Handler{
 		store:            db,
+		provider:         provider.NewRegistry(palworld.NewProvider()),
 		runtime:          runtime.NewSwitchableAdapter(adapter),
 		runtimeImageJobs: map[string]domain.RuntimeImageStatus{},
 	}, db, dataDir

--- a/apps/api/internal/http/handler.go
+++ b/apps/api/internal/http/handler.go
@@ -143,6 +143,8 @@ func (h *Handler) Register(r chi.Router) {
 		r.Get("/api/games", h.listGames)
 		r.Get("/api/games/{gameKey}", h.getGame)
 		r.Get("/api/games/{gameKey}/versions", h.gameVersions)
+		r.Post("/api/providers/{providerKey}/game-update/check", h.checkProviderGameUpdate)
+		r.Put("/api/providers/{providerKey}/game-update/auto-check", h.updateProviderGameUpdateAutoCheck)
 		r.Get("/api/config-presets", h.listConfigPresets)
 		r.Post("/api/config-presets", h.createConfigPreset)
 		r.Get("/api/config-presets/{id}", h.getConfigPreset)

--- a/apps/api/internal/runtime/docker/game_update.go
+++ b/apps/api/internal/runtime/docker/game_update.go
@@ -96,15 +96,10 @@ var (
 )
 
 func (a *Adapter) CheckGameUpdate(ctx context.Context, request runtime.GameUpdateRequest) (runtime.GameUpdateResult, error) {
-	dataDir, err := validateGameUpdateRequest(request)
-	if err != nil {
+	if err := validateGameUpdateCheckRequest(request); err != nil {
 		return runtime.GameUpdateResult{}, err
 	}
-	installed, err := readInstalledBuildID(dataDir, request.AppID)
-	if err != nil {
-		return runtime.GameUpdateResult{}, err
-	}
-	output, err := a.runGameUpdater(ctx, request, dataDir, true, checkGameUpdateScript, nil)
+	output, err := a.runGameUpdater(ctx, request, "", true, checkGameUpdateScript, nil)
 	if err != nil {
 		return runtime.GameUpdateResult{}, err
 	}
@@ -112,7 +107,20 @@ func (a *Adapter) CheckGameUpdate(ctx context.Context, request runtime.GameUpdat
 	if err != nil {
 		return runtime.GameUpdateResult{}, fmt.Errorf("parse latest Steam build for app %s: %w", request.AppID, err)
 	}
-	return runtime.GameUpdateResult{InstalledBuildID: installed, LatestBuildID: latest}, nil
+	return runtime.GameUpdateResult{LatestBuildID: latest}, nil
+}
+
+func validateGameUpdateCheckRequest(request runtime.GameUpdateRequest) error {
+	if strings.TrimSpace(request.JobID) == "" || containerNameClean.ReplaceAllString(request.JobID, "") != request.JobID {
+		return fmt.Errorf("invalid game update job ID")
+	}
+	if strings.TrimSpace(request.Image) == "" {
+		return fmt.Errorf("game update image is required")
+	}
+	if !appIDPattern.MatchString(request.AppID) {
+		return fmt.Errorf("invalid Steam app ID %q", request.AppID)
+	}
+	return nil
 }
 
 func (a *Adapter) ApplyGameUpdate(ctx context.Context, request runtime.GameUpdateRequest, onProgress runtime.GameUpdateProgressFunc) (runtime.GameUpdateResult, error) {
@@ -205,10 +213,8 @@ func (a *Adapter) runGameUpdater(
 		namePart = namePart[:48]
 	}
 	containerName := fmt.Sprintf("gamepanel-updater-%s-%d", namePart, time.Now().UnixNano())
-	memoryLimit := int64(1536 * 1024 * 1024)
-	if readOnly {
-		memoryLimit = 512 * 1024 * 1024
-	}
+	resources := gameUpdaterResources(readOnly)
+	mounts := gameUpdaterMounts(dataDir, readOnly)
 	resp, err := a.client.ContainerCreate(ctx, &container.Config{
 		Image:      request.Image,
 		Entrypoint: []string{"/bin/sh", "-lc"},
@@ -224,16 +230,8 @@ func (a *Adapter) runGameUpdater(
 	}, &container.HostConfig{
 		AutoRemove:  false,
 		SecurityOpt: []string{"no-new-privileges:true"},
-		Resources: container.Resources{
-			NanoCPUs: 2_000_000_000,
-			Memory:   memoryLimit,
-		},
-		Mounts: []mount.Mount{{
-			Type:     mount.TypeBind,
-			Source:   dataDir,
-			Target:   "/palworld",
-			ReadOnly: readOnly,
-		}},
+		Resources:   resources,
+		Mounts:      mounts,
 	}, nil, nil, containerName)
 	if err != nil {
 		return "", fmt.Errorf("create controlled game updater: %w", err)
@@ -311,6 +309,36 @@ func (a *Adapter) runGameUpdater(
 		}
 	}
 	return output.String(), fmt.Errorf("controlled game updater exited without a status")
+}
+
+// Metadata checks still need SteamCMD to obtain the public branch Build ID,
+// but they must not compete with a running game server for the host's CPU.
+// They also do not need access to the game files: the installed Build ID is
+// read by the API before the helper starts. Keeping the data directory out of
+// the helper prevents SteamCMD metadata refreshes from generating I/O on the
+// live server mount.
+func gameUpdaterResources(metadataOnly bool) container.Resources {
+	if metadataOnly {
+		return container.Resources{
+			NanoCPUs: 250_000_000,
+			Memory:   512 * 1024 * 1024,
+		}
+	}
+	return container.Resources{
+		NanoCPUs: 2_000_000_000,
+		Memory:   1536 * 1024 * 1024,
+	}
+}
+
+func gameUpdaterMounts(dataDir string, metadataOnly bool) []mount.Mount {
+	if metadataOnly {
+		return nil
+	}
+	return []mount.Mount{{
+		Type:   mount.TypeBind,
+		Source: dataDir,
+		Target: "/palworld",
+	}}
 }
 
 func (a *Adapter) CleanupGameUpdate(ctx context.Context, jobID string) error {

--- a/apps/api/internal/runtime/docker/game_update_test.go
+++ b/apps/api/internal/runtime/docker/game_update_test.go
@@ -38,6 +38,37 @@ func TestValidateGameUpdateRequestRequiresSafeJobID(t *testing.T) {
 	}
 }
 
+func TestValidateGameUpdateCheckRequestDoesNotRequireServerInstance(t *testing.T) {
+	request := runtime.GameUpdateRequest{JobID: "provider-check-1", Image: "palworld:latest", AppID: "2394010"}
+	if err := validateGameUpdateCheckRequest(request); err != nil {
+		t.Fatalf("expected provider-scoped check request to be valid: %v", err)
+	}
+}
+
+func TestGameUpdateMetadataCheckUsesIsolatedLowResources(t *testing.T) {
+	resources := gameUpdaterResources(true)
+	if resources.NanoCPUs != 250_000_000 {
+		t.Fatalf("expected metadata check to use 0.25 CPU, got %d NanoCPUs", resources.NanoCPUs)
+	}
+	if resources.Memory != 512*1024*1024 {
+		t.Fatalf("expected metadata check to use 512 MiB, got %d bytes", resources.Memory)
+	}
+	if mounts := gameUpdaterMounts("/srv/palworld", true); len(mounts) != 0 {
+		t.Fatalf("expected metadata check not to mount live game data, got %#v", mounts)
+	}
+}
+
+func TestGameUpdateApplyKeepsGameDataMountAndResources(t *testing.T) {
+	resources := gameUpdaterResources(false)
+	if resources.NanoCPUs != 2_000_000_000 || resources.Memory != 1536*1024*1024 {
+		t.Fatalf("unexpected apply resources: %#v", resources)
+	}
+	mounts := gameUpdaterMounts("/srv/palworld", false)
+	if len(mounts) != 1 || mounts[0].Source != "/srv/palworld" || mounts[0].Target != "/palworld" || mounts[0].ReadOnly {
+		t.Fatalf("expected writable game data mount for update apply, got %#v", mounts)
+	}
+}
+
 func TestCleanupGameUpdateFiltersByJobAndForceRemovesHelpers(t *testing.T) {
 	var mu sync.Mutex
 	filterValue := ""

--- a/apps/api/internal/store/store.go
+++ b/apps/api/internal/store/store.go
@@ -165,6 +165,18 @@ func (s *Store) GetLatestGameUpdateJobByInstance(ctx context.Context, instanceID
 	return job, err
 }
 
+func (s *Store) GetLatestGameUpdateCheckByProvider(ctx context.Context, providerKey domain.ProviderKey) (domain.GameUpdateJob, error) {
+	var job domain.GameUpdateJob
+	err := s.db.WithContext(ctx).
+		Where("provider_key = ? AND operation = ?", providerKey, domain.GameUpdateOperationCheck).
+		Order("created_at desc, rowid desc").
+		First(&job).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return job, ErrNotFound
+	}
+	return job, err
+}
+
 func (s *Store) GetActiveGameUpdateJobByInstance(ctx context.Context, instanceID string) (domain.GameUpdateJob, error) {
 	var job domain.GameUpdateJob
 	err := s.db.WithContext(ctx).

--- a/apps/web/app/games/page.tsx
+++ b/apps/web/app/games/page.tsx
@@ -3,13 +3,13 @@
 import Image from "next/image";
 import Link from "next/link";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { AlertTriangle, CheckCircle2, Download, Loader2, Plus } from "lucide-react";
+import { AlertTriangle, CheckCircle2, Download, Loader2, Plus, RefreshCw } from "lucide-react";
 import { Button, Card } from "@/components/ui";
 import { PageHeader } from "@/components/page-header";
 import { getGameArt } from "@/lib/game-art";
 import { gameDescription, gameDisplayName } from "@/lib/game-display";
 import { useI18n, type MessageKey } from "@/lib/i18n";
-import { listGames, prepareRuntimeImage } from "@/lib/api";
+import { checkProviderGameUpdate, listGames, prepareRuntimeImage } from "@/lib/api";
 import { providerDescription, providerDisplayName } from "@/lib/provider-display";
 import { formatRuntimeInstallError } from "@/lib/runtime-errors";
 import { isRuntimeImagePreparing, isRuntimeImageReady, runtimeImageLabelKey, runtimeImageTone } from "@/lib/runtime-image";
@@ -23,7 +23,7 @@ export default function GamesPage() {
     queryKey: ["games"],
     queryFn: listGames,
     retry: false,
-    refetchInterval: (query) => hasPreparingRuntime(query.state.data) ? 1000 : false
+    refetchInterval: (query) => hasActiveGameLibraryTask(query.state.data) ? 1000 : false
   });
   const install = useMutation({
     mutationFn: ({ providerKey, version }: { providerKey: ProviderKey; version?: string }) => prepareRuntimeImage(providerKey, version),
@@ -32,6 +32,10 @@ export default function GamesPage() {
     }
   });
   const games = gamesQuery.data ?? [];
+  const versionCheck = useMutation({
+    mutationFn: (providerKey: ProviderKey) => checkProviderGameUpdate(providerKey),
+    onSuccess: async () => queryClient.invalidateQueries({ queryKey: ["games"] })
+  });
 
   return (
     <>
@@ -46,6 +50,7 @@ export default function GamesPage() {
             installingProvider={install.variables?.providerKey}
             isInstalling={install.isPending}
             onInstall={(provider) => install.mutate({ providerKey: provider.key, version: provider.recommendedVersion })}
+            onVersionCheck={(provider) => versionCheck.mutate(provider.key)}
           />
         ))}
       </div>
@@ -59,13 +64,15 @@ function GameRuntimeCard({
   installError,
   installingProvider,
   isInstalling,
-  onInstall
+  onInstall,
+  onVersionCheck
 }: {
   game: GameCatalogEntry;
   installError: string;
   installingProvider?: ProviderKey;
   isInstalling: boolean;
   onInstall: (provider: ProviderCatalog) => void;
+  onVersionCheck: (provider: ProviderCatalog) => void;
 }) {
   const { t } = useI18n();
   const art = getGameArt(game.coverImage ?? game.key);
@@ -114,6 +121,7 @@ function GameRuntimeCard({
                 installingProvider={installingProvider}
                 isInstalling={isInstalling}
                 onInstall={onInstall}
+                onVersionCheck={onVersionCheck}
                 provider={provider}
                 showProviderTitle={hasMultipleProviders}
               />
@@ -132,6 +140,7 @@ function ProviderRuntimeRow({
   installingProvider,
   isInstalling,
   onInstall,
+  onVersionCheck,
   provider,
   showProviderTitle
 }: {
@@ -140,6 +149,7 @@ function ProviderRuntimeRow({
   installingProvider?: ProviderKey;
   isInstalling: boolean;
   onInstall: (provider: ProviderCatalog) => void;
+  onVersionCheck: (provider: ProviderCatalog) => void;
   provider: ProviderCatalog;
   showProviderTitle: boolean;
 }) {
@@ -173,11 +183,23 @@ function ProviderRuntimeRow({
         </div>
         <p className="mt-1 max-w-2xl text-sm text-slate-400">{providerDescription(provider.key, provider.description, t)}</p>
         <p className="mt-2 text-xs text-slate-500">{statusHint}</p>
+        {provider.gameVersion?.supported ? (
+          <p className="mt-1 text-xs text-slate-500">
+            {t("gameUpdateLatestBuild")}: <span className="font-mono text-slate-300">{provider.gameVersion.latestBuildId || "—"}</span>
+            {provider.gameVersion.checkedAt ? ` · ${new Date(provider.gameVersion.checkedAt).toLocaleString()}` : ""}
+		  </p>
+        ) : null}
         {preparing ? <RuntimeInstallProgress /> : null}
         {failed && status?.message ? <p className="mt-2 text-xs text-panel-gold">{formatRuntimeInstallError(status.message, t)}</p> : null}
         {failed && installError ? <p className="mt-1 text-xs text-panel-gold">{installError}</p> : null}
       </div>
       <div className="flex shrink-0 items-center gap-2">
+        {provider.gameVersion?.supported ? (
+          <Button type="button" variant="secondary" className="h-10" disabled={provider.gameVersion.status === "checking"} onClick={() => onVersionCheck(provider)}>
+            <RefreshCw aria-hidden="true" className={cn("size-4", provider.gameVersion.status === "checking" && "animate-spin")} />
+            {provider.gameVersion.status === "checking" ? t("gameUpdateStatusChecking") : t("gameUpdateCheck")}
+          </Button>
+        ) : null}
         {ready ? (
           <Link
             href={`/servers/new?game=${encodeURIComponent(game.key)}&provider=${encodeURIComponent(provider.key)}${provider.recommendedVersion ? `&version=${encodeURIComponent(provider.recommendedVersion)}` : ""}`}
@@ -235,8 +257,8 @@ function RuntimeStatusBadge({ status }: { status?: RuntimeImageStatus }) {
   );
 }
 
-function hasPreparingRuntime(games?: GameCatalogEntry[]) {
-  return Boolean(games?.some((game) => game.providers.some((provider) => provider.runtimeImage?.status === "preparing")));
+function hasActiveGameLibraryTask(games?: GameCatalogEntry[]) {
+  return Boolean(games?.some((game) => game.providers.some((provider) => provider.runtimeImage?.status === "preparing" || provider.gameVersion?.status === "checking")));
 }
 
 function runtimeInstallPhaseMessageKey(status?: RuntimeImageStatus): MessageKey {

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -121,6 +121,11 @@ export async function prepareRuntimeImage(providerKey: ProviderKey, version?: st
   return readPayload<RuntimeImageStatus>(response, "Unable to install server runtime");
 }
 
+export async function checkProviderGameUpdate(providerKey: ProviderKey): Promise<GameUpdateJob> {
+  const response = await apiFetch(`${API_BASE}/api/providers/${providerKey}/game-update/check`, { method: "POST" });
+  return readPayload<GameUpdateJob>(response, "Unable to check the provider game version");
+}
+
 export async function previewTerrariaConfig(config: TerrariaConfig): Promise<string> {
   const response = await apiFetch(`${API_BASE}/api/terraria/config/preview`, {
     method: "POST",

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -51,6 +51,17 @@ export type ProviderCatalog = {
   configSchema: ProviderConfigField[];
   saveDisplayName?: string;
   runtimeImage?: RuntimeImageStatus;
+  gameVersion?: ProviderVersionStatus;
+};
+
+export type ProviderVersionStatus = {
+  supported: boolean;
+  status: "unknown" | "checking" | "ready" | "failed" | "unsupported" | string;
+  latestBuildId?: string;
+  checkedAt?: string;
+  autoCheckEnabled: boolean;
+  autoCheckIntervalHours: number;
+  job?: GameUpdateJob;
 };
 
 export type GameCatalogEntry = {

--- a/packages/contracts/openapi.yaml
+++ b/packages/contracts/openapi.yaml
@@ -293,7 +293,7 @@ paths:
           type: string
     get:
       summary: Read game update state
-      description: Returns the latest persisted update task and build metadata. Only the Palworld provider currently reports supported=true.
+      description: Compares this server's installed build with the latest Provider-scoped game-library check. Only the Palworld provider currently reports supported=true.
       responses:
         "200":
           description: Current game update state
@@ -315,7 +315,7 @@ paths:
           type: string
     post:
       summary: Queue a game update check
-      description: Creates a persistent asynchronous task that refreshes Steam metadata and compares the installed and latest build IDs.
+      description: Compatibility alias that queues one Provider-scoped game-library version check shared by every server of this type.
       responses:
         "202":
           description: Update check accepted
@@ -333,6 +333,53 @@ paths:
           description: Update check task could not be created
         "503":
           description: Docker runtime is unavailable or lacks safe update support
+  /api/providers/{providerKey}/game-update/check:
+    parameters:
+      - name: providerKey
+        in: path
+        required: true
+        schema:
+          $ref: "#/components/schemas/ProviderKey"
+    post:
+      summary: Queue a Provider-scoped game version check
+      description: Refreshes the latest upstream build once for the game-library Provider. All matching server instances reuse the result.
+      responses:
+        "202":
+          description: Provider version check accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GameUpdateJob"
+        "400":
+          description: Version checks are unsupported for this Provider
+        "409":
+          description: Another heavy runtime task is active
+        "503":
+          description: Docker runtime is unavailable
+  /api/providers/{providerKey}/game-update/auto-check:
+    parameters:
+      - name: providerKey
+        in: path
+        required: true
+        schema:
+          $ref: "#/components/schemas/ProviderKey"
+    put:
+      summary: Configure Provider-scoped automatic version checks
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [enabled]
+              properties:
+                enabled:
+                  type: boolean
+      responses:
+        "200":
+          description: Automatic check setting updated
+        "400":
+          description: Invalid setting or unsupported Provider
   /api/servers/{id}/game-update/apply:
     parameters:
       - name: id


### PR DESCRIPTION
## Summary
- move game version checks from individual servers to provider-scoped shared state
- expose provider version state and checks in the game library
- compare each Palworld server manifest against the shared latest build
- isolate SteamCMD metadata checks to 0.25 CPU / 512 MiB without mounting live game data
- keep server update application instance-scoped

## Verification
- go test ./...
- go vet ./...
- pnpm --dir apps/web lint
- pnpm --dir apps/web typecheck
- pnpm --dir apps/web build