### PR TITLE
fix: refresh DST game files on restart

### DIFF
--- a/apps/api/internal/http/server_handlers_test.go
+++ b/apps/api/internal/http/server_handlers_test.go
@@ -524,7 +524,7 @@ func TestCreateDSTServerUsesDSTRuntimeSpec(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("expected async start to create runtime container")
 	}
-	if spec.Image != "smartcat99999/dst-server:v2026.07.17" {
+	if spec.Image != "smartcat99999/dst-server:v2026.08.14" {
 		t.Fatalf("expected DST image, got %q", spec.Image)
 	}
 	if spec.Port != 10999 || spec.Options.PortProtocol != "udp" {

--- a/apps/api/internal/provider/dst/entrypoint_test.go
+++ b/apps/api/internal/provider/dst/entrypoint_test.go
@@ -26,6 +26,9 @@ func TestDSTEntrypointReusesCompleteWorkshopCacheOnStart(t *testing.T) {
 	if strings.Contains(log, "-only_update_server_mods") {
 		t.Fatalf("expected start to skip mod download, got %q", log)
 	}
+	if _, err := os.Stat(filepath.Join(dataDir, "fake-steamcmd.log")); !os.IsNotExist(err) {
+		t.Fatalf("expected ordinary start to reuse game files without SteamCMD, stat err=%v", err)
+	}
 	if strings.Contains(log, "-console") {
 		t.Fatalf("expected shard startup to omit deprecated -console, got %q", log)
 	}
@@ -44,6 +47,16 @@ func TestDSTEntrypointRefreshesAllWorkshopModsOnRestart(t *testing.T) {
 	}
 	if !strings.Contains(output, "Refreshed and verified all GamePanel DST server mods.") {
 		t.Fatalf("expected refresh success message, got:\n%s", output)
+	}
+	steamLog := readTestFile(t, filepath.Join(dataDir, "fake-steamcmd.log"))
+	if !strings.Contains(steamLog, "+app_update 343050") {
+		t.Fatalf("expected restart to update DST game files, got %q", steamLog)
+	}
+	if strings.Contains(steamLog, "validate") {
+		t.Fatalf("expected restart update to avoid an expensive full validation, got %q", steamLog)
+	}
+	if got := strings.TrimSpace(readTestFile(t, filepath.Join(dataDir, ".gamepanel", "dst-build-id"))); got != "24700372" {
+		t.Fatalf("expected installed build marker, got %q", got)
 	}
 	if _, err := os.Stat(filepath.Join(dataDir, "ugc_mods", "old-cache")); !os.IsNotExist(err) {
 		t.Fatalf("expected old cache to be atomically replaced, stat err=%v", err)
@@ -188,6 +201,23 @@ fi
 	if err := os.Chmod(filepath.Join(root, "server", "bin64", "dontstarve_dedicated_server_nullrenderer_x64"), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	fakeSteamCMD := `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${DST_PERSISTENT_ROOT}/fake-steamcmd.log"
+mkdir -p "${DST_ROOT_DIR}/server/steamapps"
+cat > "${DST_ROOT_DIR}/server/steamapps/appmanifest_343050.acf" <<'EOF'
+"AppState"
+{
+  "appid" "343050"
+  "StateFlags" "4"
+  "buildid" "24700372"
+}
+EOF
+`
+	writeTestFile(t, filepath.Join(root, "fake-steamcmd"), fakeSteamCMD)
+	if err := os.Chmod(filepath.Join(root, "fake-steamcmd"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 
 	script, err := filepath.Abs(filepath.Join("..", "..", "..", "..", "..", "docker", "dst", "gamepanel-dst-entrypoint.sh"))
 	if err != nil {
@@ -214,6 +244,8 @@ func runDSTEntrypoint(t *testing.T, root, dataDir, script, mode string) (string,
 		"DST_CONF_DIR=dst",
 		"DST_CLUSTER_NAME=GamePanelLite",
 		"DST_MOD_SYNC_MODE="+mode,
+		"DST_GAME_UPDATE_MODE="+mode,
+		"DST_STEAMCMD_BIN="+filepath.Join(root, "fake-steamcmd"),
 	)
 	output, err := cmd.CombinedOutput()
 	return string(output), err

--- a/apps/api/internal/provider/dst/provider.go
+++ b/apps/api/internal/provider/dst/provider.go
@@ -20,7 +20,7 @@ const (
 	DefaultCavesShardID = "2"
 )
 
-var versions = []string{"v2026.07.17", "v2026.06.21"}
+var versions = []string{"v2026.08.14", "v2026.07.17", "v2026.06.21"}
 
 type Provider struct {
 	runtime runtimecatalog.RuntimeConfig

--- a/apps/api/internal/provider/dst/provider_test.go
+++ b/apps/api/internal/provider/dst/provider_test.go
@@ -299,7 +299,7 @@ func TestRuntimeOptionsRenderDSTFiles(t *testing.T) {
 	provider := NewProvider()
 	options := runtimeOptions(config)
 
-	if provider.ImageFor("") != "smartcat99999/dst-server:v2026.07.17" {
+	if provider.ImageFor("") != "smartcat99999/dst-server:v2026.08.14" {
 		t.Fatalf("unexpected DST image: %s", provider.ImageFor(""))
 	}
 	if options.PortProtocol != "udp" {

--- a/apps/api/internal/server/workload.go
+++ b/apps/api/internal/server/workload.go
@@ -97,6 +97,7 @@ func runtimeEnvironment(providerEnv []string, server domain.GameServer) []string
 	env = append(env, server.Spec.Runtime.Env...)
 	if server.ProviderKey == domain.ProviderDST && server.Spec.Runtime.ModSyncMode != "" {
 		env = append(env, "DST_MOD_SYNC_MODE="+server.Spec.Runtime.ModSyncMode)
+		env = append(env, "DST_GAME_UPDATE_MODE="+server.Spec.Runtime.ModSyncMode)
 	}
 	return env
 }

--- a/apps/api/internal/server/workload_test.go
+++ b/apps/api/internal/server/workload_test.go
@@ -97,6 +97,9 @@ func TestProviderWorkloadBuilderPassesDSTModSyncMode(t *testing.T) {
 	if !containsEnv(spec.Options.Env, "DST_MOD_SYNC_MODE=refresh") {
 		t.Fatalf("expected DST refresh mode in workload env, got %+v", spec.Options.Env)
 	}
+	if !containsEnv(spec.Options.Env, "DST_GAME_UPDATE_MODE=refresh") {
+		t.Fatalf("expected DST game update mode in workload env, got %+v", spec.Options.Env)
+	}
 }
 
 func TestProviderWorkloadBuilderPlansDesiredModsFromServerSpec(t *testing.T) {

--- a/config/providers.json
+++ b/config/providers.json
@@ -15,7 +15,7 @@
     },
     "dont-starve-together": {
       "imageTemplate": "{registry}/dst-server:{version}",
-      "versions": ["v2026.07.17", "v2026.06.21"]
+      "versions": ["v2026.08.14", "v2026.07.17", "v2026.06.21"]
     },
     "palworld": {
       "imageTemplate": "{registry}/palworld-server:{version}",

--- a/docker/dst/Dockerfile
+++ b/docker/dst/Dockerfile
@@ -1,17 +1,31 @@
 # syntax=docker/dockerfile:1.7
 
-# SteamCMD occasionally returns "Missing configuration" for the public DST app
-# even though app 343050 supports anonymous installation. Use a digest-pinned,
-# preinstalled upstream image as the binary source so builds stay reproducible
-# and never require a personal Steam account.
-ARG DST_BASE_IMAGE=webhippie/dst@sha256:798067e88a9120bb5635cec18d125d430bb7e8be26f84f943f2cfee906705891
-FROM ${DST_BASE_IMAGE} AS installer
+ARG STEAMCMD_IMAGE=steamcmd/steamcmd@sha256:aed94b9fa7322488a36f97d0842cd0df1d73d79d592ea0b6f39b3a8fba7076de
+FROM ${STEAMCMD_IMAGE} AS installer
+ARG DST_IMAGE_VERSION=v2026.08.14
+
+RUN --mount=type=cache,id=gamepanel-dst-steam-library,target=/var/cache/dst,sharing=locked \
+    echo "Building DST runtime ${DST_IMAGE_VERSION}" \
+    && installed=0 \
+    && for attempt in 1 2 3; do \
+         if /usr/games/steamcmd +force_install_dir /var/cache/dst +login anonymous +app_update 343050 validate +quit; then \
+           installed=1; \
+           break; \
+         fi; \
+         echo "DST image install attempt ${attempt} failed" >&2; \
+       done \
+    && test "${installed}" = "1" \
+    && test -x /var/cache/dst/bin64/dontstarve_dedicated_server_nullrenderer_x64 \
+    && grep -Eq '"StateFlags"[[:space:]]+"4"' /var/cache/dst/steamapps/appmanifest_343050.acf \
+    && rm -rf /opt/dst \
+    && mkdir -p /opt/dst \
+    && cp -a /var/cache/dst/. /opt/dst/
 
 FROM debian:bookworm-slim
 
 LABEL org.opencontainers.image.title="GamePanel Lite Don't Starve Together"
 LABEL org.opencontainers.image.description="Prebuilt Don't Starve Together dedicated server runtime for GamePanel Lite"
-LABEL org.opencontainers.image.base.name="docker.io/webhippie/dst@sha256:798067e88a9120bb5635cec18d125d430bb7e8be26f84f943f2cfee906705891"
+LABEL org.opencontainers.image.base.name="docker.io/steamcmd/steamcmd@sha256:aed94b9fa7322488a36f97d0842cd0df1d73d79d592ea0b6f39b3a8fba7076de"
 
 RUN dpkg --add-architecture i386 \
     && apt-get update \
@@ -23,11 +37,14 @@ RUN dpkg --add-architecture i386 \
 
 USER container
 WORKDIR /home/container
-COPY --from=installer --chown=container:container /usr/share/game/ /home/container/server/
+COPY --from=installer --chown=container:container /opt/dst/ /home/container/server/
+COPY --from=installer /usr/games/steamcmd /usr/games/steamcmd
+COPY --from=installer /usr/lib/games/steam/ /usr/lib/games/steam/
 COPY --chmod=755 --chown=container:container docker/dst/gamepanel-dst-entrypoint.sh /home/container/gamepanel-dst-entrypoint.sh
 
 ENV DST_PERSISTENT_ROOT=/data
 ENV DST_CONF_DIR=dst
 ENV DST_CLUSTER_NAME=GamePanelLite
+ENV HOME=/home/container
 
 CMD ["./gamepanel-dst-entrypoint.sh"]

--- a/docker/dst/gamepanel-dst-entrypoint.sh
+++ b/docker/dst/gamepanel-dst-entrypoint.sh
@@ -9,8 +9,49 @@ CLUSTER_NAME="${DST_CLUSTER_NAME:-GamePanelLite}"
 CLUSTER_DIR="${PERSISTENT_ROOT}/${CONF_DIR}/${CLUSTER_NAME}"
 UGC_DIR="${DST_UGC_DIRECTORY:-${PERSISTENT_ROOT}/ugc_mods}"
 MOD_SYNC_MODE="${DST_MOD_SYNC_MODE:-reuse}"
+GAME_UPDATE_MODE="${DST_GAME_UPDATE_MODE:-${MOD_SYNC_MODE}}"
+DST_STEAM_APP_ID="${DST_STEAM_APP_ID:-343050}"
+STEAMCMD_BIN="${DST_STEAMCMD_BIN:-/usr/games/steamcmd}"
 LEGACY_WORKSHOP_FALLBACK="${DST_LEGACY_WORKSHOP_FALLBACK:-1}"
 WORKSHOP_DETAILS_ENDPOINT="${DST_WORKSHOP_DETAILS_ENDPOINT:-https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/v1/}"
+
+record_installed_build() {
+  local manifest="${SERVER_DIR}/steamapps/appmanifest_${DST_STEAM_APP_ID}.acf"
+  local build_id=""
+  [[ -f "${manifest}" ]] || return 0
+  build_id="$(sed -n 's/^[[:space:]]*"buildid"[[:space:]]*"\([0-9][0-9]*\)".*/\1/p' "${manifest}" | head -n 1)"
+  [[ -n "${build_id}" ]] || return 0
+  mkdir -p "${PERSISTENT_ROOT}/.gamepanel"
+  printf '%s\n' "${build_id}" >"${PERSISTENT_ROOT}/.gamepanel/dst-build-id"
+}
+
+update_server_game() {
+  if [[ "${GAME_UPDATE_MODE}" != "refresh" ]]; then
+    record_installed_build
+    return 0
+  fi
+  if [[ ! -x "${STEAMCMD_BIN}" ]]; then
+    echo "DST restart update requires SteamCMD at ${STEAMCMD_BIN}." >&2
+    exit 1
+  fi
+
+  local attempt
+  echo "Checking for DST game updates before restart..."
+  for attempt in 1 2 3; do
+    if "${STEAMCMD_BIN}" \
+      +force_install_dir "${SERVER_DIR}" \
+      +login anonymous \
+      +app_update "${DST_STEAM_APP_ID}" \
+      +quit; then
+      record_installed_build
+      echo "DST game files are up to date."
+      return 0
+    fi
+    echo "DST game update attempt ${attempt} failed." >&2
+  done
+  echo "DST game update failed after 3 attempts; the server will not start with stale files." >&2
+  exit 1
+}
 
 server_bin() {
   if [[ -x "${SERVER_DIR}/bin64/dontstarve_dedicated_server_nullrenderer_x64" ]]; then
@@ -307,6 +348,7 @@ terminate_children() {
   fi
 }
 
+update_server_game
 ensure_cluster_layout
 sync_server_mods
 install_native_workshop_manifest "${UGC_DIR}" >/dev/null

--- a/scripts/build-game-images.sh
+++ b/scripts/build-game-images.sh
@@ -150,6 +150,7 @@ build_dst() {
   echo "==> Building ${image}"
   docker "${dst_buildx_args[@]}" \
     -f docker/dst/Dockerfile \
+    --build-arg "DST_IMAGE_VERSION=${version}" \
     -t "${image}" \
     "${root_dir}"
 }
@@ -179,7 +180,7 @@ if [[ "$target" == "all" || "$target" == "tmodloader" ]]; then
 fi
 
 if [[ "$target" == "dst" ]]; then
-  build_dst "v2026.07.17"
+  build_dst "v2026.08.14"
 fi
 
 if [[ "$target" == "palworld" ]]; then


### PR DESCRIPTION
## Summary
- keep versioned DST runtime images as the game-library baseline
- run an incremental SteamCMD app_update 343050 only on server restart
- keep ordinary starts on cached game files
- publish DST runtime catalog version v2026.08.14
- cache build-time Steam downloads with the native amd64 buildx builder

## Verification
- go test ./apps/api/internal/provider/dst ./apps/api/internal/server ./apps/api/internal/http
- go test ./...
- go vet ./...
- pnpm --dir apps/web lint
- pnpm --dir apps/web typecheck
- pnpm --dir apps/web build
- native linux/amd64 Docker build with my-builder