### PR TITLE
feat: redesign dashboard and server management views

### DIFF
--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -1,187 +1,228 @@
 "use client";
 
+import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
-import { Activity, Cpu, HardDrive, MemoryStick, Server as ServerIcon, Users } from "lucide-react";
+import { Activity, CheckCircle2, CircleAlert, Container, Plus, Server } from "lucide-react";
+import { useState } from "react";
+import { ResourceTrendChart } from "@/components/dashboard-charts";
 import { PageHeader } from "@/components/page-header";
-import { GameLibrary } from "@/components/game-library";
-import { ServerCard } from "@/components/server-card";
-import { Card } from "@/components/ui";
+import { ServerResourceTable } from "@/components/server-resource-table";
+import { Button } from "@/components/ui";
+import { getPlatformMonitoring } from "@/features/monitoring/api";
+import type { MetricSeries } from "@/features/monitoring/types";
 import { formatActivityEvent } from "@/lib/activity-display";
 import { isWorldOrBackupEventType } from "@/lib/feature-flags";
-import { gameServerMaxPlayers, gameServerStatus } from "@/lib/game-server-resource";
+import { gameServerStatus } from "@/lib/game-server-resource";
 import { localizeRelativeTime, useI18n } from "@/lib/i18n";
-import { formatBytes, getRuntimeStats, listActivity, listGameServers } from "@/lib/api";
-import { Sparkline, useTimeSeries } from "@/lib/sparkline";
+import { getApiHealth, getDockerStatus, getObservabilityMetrics, getSettings, listActivity, listGameServers } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+type DashboardRange = "1h" | "6h" | "24h" | "168h";
+type DashboardMetric = "nodeCpu" | "nodeMemory" | "nodeNetwork";
+
+const rangeOptions: { label: string; value: DashboardRange; step: string }[] = [
+  { label: "1h", value: "1h", step: "1m" },
+  { label: "6h", value: "6h", step: "5m" },
+  { label: "24h", value: "24h", step: "15m" },
+  { label: "7d", value: "168h", step: "1h" }
+];
 
 export default function DashboardPage() {
   const { locale, t } = useI18n();
-  const serversQuery = useQuery({ queryKey: ["game-servers"], queryFn: listGameServers, retry: false, refetchInterval: 5000 });
-  const activityQuery = useQuery({ queryKey: ["activity"], queryFn: listActivity, retry: false });
-  const runtimeStatsQuery = useQuery({ queryKey: ["runtime-stats"], queryFn: getRuntimeStats, refetchInterval: 5000, retry: false });
-  const runtimeCpuSeries = useTimeSeries(runtimeStatsQuery.data?.totalCpuPercent);
-  const runtimeMemSeries = useTimeSeries(runtimeStatsQuery.data?.totalMemoryMb, 60);
+  const [range, setRange] = useState<DashboardRange>("1h");
+  const [metricKey, setMetricKey] = useState<DashboardMetric>("nodeCpu");
+  const step = rangeOptions.find((item) => item.value === range)?.step ?? "1m";
+  const serversQuery = useQuery({ queryKey: ["game-servers"], queryFn: listGameServers, retry: false, refetchInterval: 10000 });
+  const activityQuery = useQuery({ queryKey: ["activity"], queryFn: listActivity, retry: false, refetchInterval: 30000 });
+  const metricsQuery = useQuery({ queryKey: ["observability-metrics"], queryFn: getObservabilityMetrics, retry: false, refetchInterval: 10000 });
+  const platformQuery = useQuery({
+    queryKey: ["monitoring-platform", range, step],
+    queryFn: () => getPlatformMonitoring(range, step),
+    retry: false,
+    refetchInterval: 30000
+  });
+  const apiQuery = useQuery({ queryKey: ["api-health"], queryFn: getApiHealth, retry: false, refetchInterval: 30000 });
+  const dockerQuery = useQuery({ queryKey: ["docker-status"], queryFn: getDockerStatus, retry: false, refetchInterval: 30000 });
+  const settingsQuery = useQuery({ queryKey: ["settings"], queryFn: getSettings, retry: false, staleTime: 5 * 60 * 1000 });
+
   const servers = serversQuery.data ?? [];
   const activity = (activityQuery.data ?? []).filter((event) => !isWorldOrBackupEventType(event.type));
   const running = servers.filter((server) => gameServerStatus(server) === "running");
-  const serversWithPlayerData = running.filter((server) => typeof server.status.playersOnline === "number");
-  const players = serversWithPlayerData.reduce((sum, server) => sum + (server.status.playersOnline ?? 0), 0);
-  const playerCapacity = serversWithPlayerData.reduce((sum, server) => sum + gameServerMaxPlayers(server), 0);
-  const playerSummaryAvailable = running.length === 0 || serversWithPlayerData.length === running.length;
-  const storageUsedBytes = runtimeStatsQuery.data?.storageUsedBytes ?? 0;
-  const memMax = Math.max(1024, runtimeStatsQuery.data?.memoryLimitMb ?? 1024);
-  const runtimeCpu = runtimeStatsQuery.data?.totalCpuPercent ?? 0;
-  const runtimeMemory = runtimeStatsQuery.data?.totalMemoryMb ?? 0;
-  const runtimeMemoryLimit = runtimeStatsQuery.data?.memoryLimitMb ?? memMax;
-  const memoryPercent = runtimeMemoryLimit > 0 ? runtimeMemory / runtimeMemoryLimit * 100 : 0;
-  const runtimeMemoryLimitLabel = runtimeStatsQuery.data ? `${runtimeMemoryLimit} MB` : "";
+  const unhealthy = servers.filter((server) => gameServerStatus(server) === "errored");
+  const onlinePlayers = (metricsQuery.data?.servers ?? []).reduce((total, server) => total + (server.playersOnline ?? 0), 0);
+  const series = platformQuery.data?.series[metricKey];
+  const featuredServers = [...servers].sort(serverPriority).slice(0, 5);
+  const hasDataError = serversQuery.isError || activityQuery.isError || metricsQuery.isError;
+
   return (
     <>
-      <PageHeader title={t("dashboardTitle")} description={t("dashboardDescription")} />
-      {(serversQuery.isError || activityQuery.isError) && <p className="mb-4 text-sm text-panel-gold">{t("apiDataUnavailable")}</p>}
-      <div className="grid gap-4 md:grid-cols-3">
-        <Stat icon={<HardDrive />} label={t("runningServers")} value={`${running.length} / ${servers.length}`} hint={t("runningHint", { count: running.length })} />
-        <Stat icon={<Users />} label={t("onlinePlayers")} value={playerSummaryAvailable ? `${players} / ${playerCapacity}` : t("unavailable")} hint={t("playersOnlineHint", { count: players, capacity: playerCapacity })} />
-        <Stat icon={<ServerIcon />} label={t("storageUsed")} value={runtimeStatsQuery.data ? formatBytes(storageUsedBytes) : "—"} hint={t("storageHint", { count: servers.length })} />
-      </div>
+      <PageHeader
+        title={t("dashboardTitle")}
+        description={t("dashboardInfrastructureDescription")}
+        action={
+          <Link href="/servers/new">
+            <Button className="h-10 px-4"><Plus aria-hidden="true" className="size-4" />{t("createServer")}</Button>
+          </Link>
+        }
+      />
 
-      <div className="mt-6 grid items-start gap-4 xl:grid-cols-[minmax(0,1fr)_360px]">
-        <div className="min-w-0 space-y-5">
-          <section>
-            <div className="mb-3 flex items-center justify-between gap-3">
-              <h2 className="text-base font-semibold">{t("activeServers")}</h2>
-              <span className="rounded-md border border-panel-line bg-slate-950/50 px-2 py-1 text-xs text-slate-500">
-                {running.length} / {servers.length}
-              </span>
+      {hasDataError ? <p className="mb-4 text-sm text-panel-gold" role="alert">{t("apiDataUnavailable")}</p> : null}
+
+      <section className="border-y border-panel-line" aria-label={t("dashboardSummary")}>
+        <dl className="grid grid-cols-2 divide-x divide-panel-line lg:grid-cols-4">
+          <SummaryItem label={t("kpiTotalServers")} value={serversQuery.isLoading ? "—" : String(servers.length)} />
+          <SummaryItem label={t("kpiRunning")} value={serversQuery.isLoading ? "—" : String(running.length)} />
+          <SummaryItem label={t("kpiOnlinePlayers")} value={metricsQuery.isLoading ? "—" : String(onlinePlayers)} />
+          <SummaryItem label={t("dashboardAlerts")} value={serversQuery.isLoading ? "—" : String(unhealthy.length)} warning={unhealthy.length > 0} />
+        </dl>
+      </section>
+
+      <section className="border-b border-panel-line py-6" aria-labelledby="resource-trend-title">
+        <div className="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
+          <div>
+            <h2 id="resource-trend-title" className="text-base font-semibold text-slate-100">{t("dashboardResourceTrend")}</h2>
+            <p className="mt-1 text-xs text-slate-500">{t("dashboardResourceTrendDescription")}</p>
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            <div className="inline-flex rounded-md border border-panel-line bg-slate-950/35 p-0.5" aria-label={t("dashboardResourceMetric")}>
+              <MetricButton active={metricKey === "nodeCpu"} onClick={() => setMetricKey("nodeCpu")}>CPU</MetricButton>
+              <MetricButton active={metricKey === "nodeMemory"} onClick={() => setMetricKey("nodeMemory")}>{t("memory")}</MetricButton>
+              <MetricButton active={metricKey === "nodeNetwork"} onClick={() => setMetricKey("nodeNetwork")}>{t("dashboardNetwork")}</MetricButton>
             </div>
-            <div className="grid gap-3">
-              {running.map((server) => <ServerCard key={server.id} server={server} />)}
-            </div>
-            {running.length === 0 && (
-              <div className="rounded-lg border border-panel-line bg-panel-card px-4 py-5 text-sm text-slate-400">
-                {t("noRunningServers")}
-              </div>
-            )}
-          </section>
-
-          <GameLibrary />
-
-          <Card className="p-4">
-            <h2 className="font-semibold">{t("recentActivity")}</h2>
-            {activity.length === 0 ? (
-              <p className="mt-3 text-sm text-slate-400">{activityQuery.isLoading ? t("loading") : t("noActivityYet")}</p>
-            ) : (
-              <div className="mt-3 space-y-2">
-                {activity.slice(0, 5).map((event) => {
-                  const display = formatActivityEvent(event, locale);
-                  return (
-                    <div key={event.id} className="flex items-start gap-3 rounded-md border border-panel-line bg-slate-950/50 px-3 py-2">
-                      <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded bg-panel-green/15 text-panel-green">
-                        <Activity aria-hidden="true" className="size-4" />
-                      </span>
-                      <div className="min-w-0">
-                        <p className="truncate text-sm text-slate-100">{display.message}</p>
-                        <p className="mt-0.5 text-xs text-slate-500">{display.typeLabel} · {localizeRelativeTime(event.created, locale)}</p>
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            )}
-          </Card>
-        </div>
-
-        <Card className="overflow-hidden">
-          <div className="px-4 py-4">
-            <div className="mb-3 flex items-center justify-between gap-3">
-              <div>
-                <h3 className="text-sm font-semibold text-slate-100">{t("runtimeOverview")}</h3>
-                <p className="mt-1 text-xs text-slate-500">{t("runtimeOverviewHint")}</p>
-              </div>
-              <span className="flex size-8 shrink-0 items-center justify-center rounded-md border border-panel-green/30 bg-panel-green/10 text-panel-green">
-                <Activity aria-hidden="true" className="size-4" />
-              </span>
-            </div>
-            <div className="space-y-3">
-              <RuntimeSignal
-                icon={<Cpu aria-hidden="true" className="size-4" />}
-                label={t("cpu")}
-                value={`${runtimeCpu.toFixed(1)}%`}
-                subValue={t("cpuUsageHint")}
-                percent={Math.min(runtimeCpu / 400 * 100, 100)}
-                sparkline={<Sparkline data={runtimeCpuSeries} width={92} height={26} color="#7bd978" max={400} />}
-              />
-              <RuntimeSignal
-                icon={<MemoryStick aria-hidden="true" className="size-4" />}
-                label={t("memory")}
-                value={runtimeStatsQuery.data ? `${runtimeMemory} MB` : "—"}
-                subValue={runtimeMemoryLimitLabel ? t("memoryLimitHint", { limit: runtimeMemoryLimitLabel }) : ""}
-                percent={Math.min(memoryPercent, 100)}
-                sparkline={<Sparkline data={runtimeMemSeries} width={92} height={26} color="#a78bfa" max={memMax} />}
-                tone="purple"
-              />
+            <div className="inline-flex items-center" aria-label={t("monitoringRange")}>
+              {rangeOptions.map((item) => (
+                <button
+                  className={cn("rounded px-2.5 py-1.5 text-xs text-slate-500 transition hover:text-slate-200 focus:outline-none focus:ring-2 focus:ring-panel-green/50", range === item.value && "bg-slate-800 text-slate-100")}
+                  key={item.value}
+                  onClick={() => setRange(item.value)}
+                  type="button"
+                >
+                  {item.label}
+                </button>
+              ))}
             </div>
           </div>
-        </Card>
+        </div>
+        <div className="mt-3 flex items-center justify-between gap-4">
+          <span className="text-xs text-slate-500">{metricTitle(metricKey, t)}</span>
+          <span className="font-mono text-sm font-semibold text-slate-200">{formatCurrentMetric(series)}</span>
+        </div>
+        <ResourceTrendChart emptyLabel={platformQuery.isLoading ? t("loading") : t("monitoringNoSamples")} series={series} />
+      </section>
+
+      <section className="border-b border-panel-line py-6" aria-labelledby="dashboard-servers-title">
+        <div className="mb-3 flex items-center justify-between gap-4">
+          <h2 id="dashboard-servers-title" className="text-base font-semibold text-slate-100">{t("dashboardServerInstances")}</h2>
+          <Link className="text-sm font-medium text-panel-green hover:text-panel-green/80" href="/servers">{t("dashboardViewAll")}</Link>
+        </div>
+        {featuredServers.length > 0 ? (
+          <ServerResourceTable
+            flat
+            limit={5}
+            metrics={metricsQuery.data?.servers}
+            publicHost={settingsQuery.data?.publicHost}
+            servers={featuredServers}
+            showVersion={false}
+          />
+        ) : (
+          <div className="py-8 text-center text-sm text-slate-500">
+            <p>{serversQuery.isLoading ? t("loading") : t("noServersYet")}</p>
+            {!serversQuery.isLoading ? <Link className="mt-2 inline-block text-panel-green" href="/servers/new">{t("createServer")}</Link> : null}
+          </div>
+        )}
+      </section>
+
+      <div className="grid border-b border-panel-line xl:grid-cols-[minmax(0,2fr)_minmax(280px,1fr)] xl:divide-x xl:divide-panel-line">
+        <section className="min-w-0 py-5 xl:pr-6" aria-labelledby="recent-events-title">
+          <div className="mb-3 flex items-center justify-between gap-4">
+            <h2 id="recent-events-title" className="text-base font-semibold text-slate-100">{t("dashboardRecentEvents")}</h2>
+            <Link className="text-sm text-slate-400 hover:text-panel-green" href="/activity">{t("dashboardViewAll")}</Link>
+          </div>
+          {activity.length === 0 ? (
+            <p className="py-5 text-sm text-slate-500">{activityQuery.isLoading ? t("loading") : t("noActivityYet")}</p>
+          ) : (
+            <div className="divide-y divide-panel-line">
+              {activity.slice(0, 5).map((event) => {
+                const display = formatActivityEvent(event, locale);
+                return (
+                  <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-4 py-3" key={event.id}>
+                    <div className="min-w-0">
+                      <p className="truncate text-sm text-slate-200">{display.typeLabel}</p>
+                      <p className="mt-0.5 truncate text-xs text-slate-500">{display.message}</p>
+                    </div>
+                    <time className="whitespace-nowrap text-xs text-slate-500">{localizeRelativeTime(event.created, locale)}</time>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </section>
+
+        <section className="min-w-0 border-t border-panel-line py-5 xl:border-t-0 xl:pl-6" aria-labelledby="system-status-title">
+          <h2 id="system-status-title" className="text-base font-semibold text-slate-100">{t("dashboardSystemStatus")}</h2>
+          <div className="mt-3 divide-y divide-panel-line">
+            <SystemStatusRow icon={<Server aria-hidden="true" />} label={t("dashboardPanelService")} loading={apiQuery.isLoading} healthy={apiQuery.data?.status === "ok"} />
+            <SystemStatusRow icon={<Container aria-hidden="true" />} label={t("docker")} loading={dockerQuery.isLoading} healthy={Boolean(dockerQuery.data?.available)} />
+            <SystemStatusRow icon={<Activity aria-hidden="true" />} label={t("dashboardMetricsService")} loading={platformQuery.isLoading} healthy={Boolean(platformQuery.data?.dataSource.connected)} />
+          </div>
+          <Link className="mt-4 inline-flex text-sm text-slate-400 hover:text-panel-green" href="/activity">{t("dashboardOpenMonitoring")}</Link>
+        </section>
       </div>
     </>
   );
 }
 
-function Stat({ icon, label, value, hint }: { icon: React.ReactNode; label: string; value: string; hint: string }) {
+function SummaryItem({ label, value, warning = false }: { label: string; value: string; warning?: boolean }) {
   return (
-    <Card className="p-5">
-      <div className="flex items-center gap-4">
-        <span className="flex size-11 items-center justify-center rounded-md bg-panel-green/15 text-panel-green">{icon}</span>
-        <div>
-          <p className="text-sm text-slate-400">{label}</p>
-          <p className="mt-1 text-2xl font-semibold">{value}</p>
-          <p className="text-xs text-slate-500">{hint}</p>
-        </div>
-      </div>
-    </Card>
+    <div className="min-w-0 px-4 py-4 first:pl-0 lg:px-6 lg:first:pl-0">
+      <dt className="text-xs text-slate-500">{label}</dt>
+      <dd className={cn("mt-1 font-mono text-xl font-semibold text-slate-100", warning && "text-panel-gold")}>{value}</dd>
+    </div>
   );
 }
 
-function RuntimeSignal({
-  icon,
-  label,
-  value,
-  subValue,
-  percent,
-  sparkline,
-  tone = "green"
-}: {
-  icon: React.ReactNode;
-  label: string;
-  value: string;
-  subValue?: string;
-  percent?: number;
-  sparkline?: React.ReactNode;
-  tone?: "green" | "purple";
-}) {
-  const colorClass = tone === "purple" ? "text-panel-purple" : "text-panel-green";
-  const barClass = tone === "purple" ? "bg-panel-purple" : "bg-panel-green";
-
+function MetricButton({ active, children, onClick }: { active: boolean; children: React.ReactNode; onClick: () => void }) {
   return (
-    <div className="rounded-md border border-panel-line bg-slate-950/35 p-3">
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0">
-          <div className="flex items-center gap-2">
-            <span className={colorClass}>{icon}</span>
-            <p className="text-xs text-slate-500">{label}</p>
-          </div>
-          <div className="mt-1 flex flex-wrap items-baseline gap-x-2 gap-y-1">
-            <p className="font-mono text-lg font-semibold text-slate-100">{value}</p>
-            {subValue && <p className="text-xs text-slate-500">{subValue}</p>}
-          </div>
-        </div>
-        {sparkline && <div className="shrink-0 pt-1">{sparkline}</div>}
-      </div>
-      {percent !== undefined && (
-        <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-slate-800">
-          <div className={`h-full rounded-full ${barClass}`} style={{ width: `${Math.max(4, Math.min(percent, 100))}%` }} />
-        </div>
-      )}
+    <button
+      className={cn("rounded px-3 py-1.5 text-xs text-slate-500 transition hover:text-slate-200 focus:outline-none focus:ring-2 focus:ring-panel-green/50", active && "bg-slate-800 text-slate-100")}
+      onClick={onClick}
+      type="button"
+    >
+      {children}
+    </button>
+  );
+}
+
+function SystemStatusRow({ healthy, icon, label, loading }: { healthy: boolean; icon: React.ReactNode; label: string; loading: boolean }) {
+  const { t } = useI18n();
+  const statusLabel = loading ? t("dockerCheckingShort") : healthy ? t("dashboardStatusNormal") : t("unavailable");
+  return (
+    <div className="flex items-center justify-between gap-4 py-3 text-sm">
+      <span className="flex items-center gap-2 text-slate-300"><span className="text-slate-500 [&>svg]:size-4">{icon}</span>{label}</span>
+      <span className={cn("inline-flex items-center gap-2", healthy ? "text-panel-green" : loading ? "text-slate-500" : "text-panel-gold")}>
+        {healthy ? <CheckCircle2 aria-hidden="true" className="size-4" /> : <CircleAlert aria-hidden="true" className="size-4" />}
+        {statusLabel}
+      </span>
     </div>
   );
+}
+
+function metricTitle(key: DashboardMetric, t: ReturnType<typeof useI18n>["t"]) {
+  if (key === "nodeMemory") return t("metricTitleNodeMemory");
+  if (key === "nodeNetwork") return t("metricTitleNodeNetwork");
+  return t("metricTitleNodeCpu");
+}
+
+function formatCurrentMetric(series?: MetricSeries) {
+  const value = series?.currentValue;
+  if (value === null || value === undefined || !Number.isFinite(value)) return "—";
+  if (series?.unit === "%") return `${value.toFixed(1)}%`;
+  if (series?.unit === "MB") return value >= 1024 ? `${(value / 1024).toFixed(1)} GB` : `${value.toFixed(0)} MB`;
+  if (series?.unit === "MB/s") return `${value.toFixed(2)} MB/s`;
+  return `${value.toFixed(1)} ${series?.unit ?? ""}`.trim();
+}
+
+function serverPriority(left: Parameters<typeof gameServerStatus>[0], right: Parameters<typeof gameServerStatus>[0]) {
+  const rank: Record<string, number> = { errored: 0, running: 1, creating: 2, starting: 2, stopping: 2, restarting: 2, stopped: 3 };
+  return (rank[gameServerStatus(left)] ?? 4) - (rank[gameServerStatus(right)] ?? 4);
 }

--- a/apps/web/app/presets/page.tsx
+++ b/apps/web/app/presets/page.tsx
@@ -1,16 +1,16 @@
 "use client";
 
 import Link from "next/link";
-import { Bookmark, Cpu, MemoryStick, Plus, Trash2 } from "lucide-react";
+import { Eye, Plus, Trash2, X } from "lucide-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { ResourceFilterBar } from "@/components/resource-filter-bar";
 import { PageHeader } from "@/components/page-header";
-import { Badge, Button, Card } from "@/components/ui";
+import { Badge, Button, ToastNotice } from "@/components/ui";
 import { deleteConfigPreset, listConfigPresets, listGames, listModPacks } from "@/lib/api";
 import { gameFilterOptions } from "@/lib/game-filters";
-import { localizeRelativeTime, useI18n, type MessageKey } from "@/lib/i18n";
+import { localizeRelativeTime, useI18n, type Locale, type MessageKey } from "@/lib/i18n";
 import { providerFilterOptions } from "@/lib/provider-filters";
 import type { ConfigPreset, GameCatalogEntry, ModPack, ProviderCatalog } from "@/lib/types";
 
@@ -27,6 +27,7 @@ export default function PresetsPage() {
   const [gameFilter, setGameFilter] = useState<PresetGameFilter>("all");
   const [providerFilter, setProviderFilter] = useState<PresetProviderFilter>("all");
   const [pendingDelete, setPendingDelete] = useState<ConfigPreset | null>(null);
+  const [selectedPreset, setSelectedPreset] = useState<ConfigPreset | null>(null);
   const [errorMessage, setErrorMessage] = useState("");
   const [successMessage, setSuccessMessage] = useState("");
   const presets = presetsQuery.data ?? [];
@@ -82,8 +83,19 @@ export default function PresetsPage() {
     <>
       <PageHeader title={t("configurationPresets")} />
       {(presetsQuery.isError || gamesQuery.isError) && <p className="mb-4 text-sm text-panel-gold">{t("apiConfigurationPresetsUnavailable")}</p>}
-      {errorMessage && <p className="mb-4 text-sm text-panel-gold">{errorMessage}</p>}
-      {successMessage && <p className="mb-4 text-sm text-panel-green">{successMessage}</p>}
+      {(errorMessage || successMessage) && (
+        <div className="pointer-events-none fixed inset-x-4 bottom-4 z-[60] flex justify-end md:inset-x-auto md:bottom-auto md:right-6 md:top-24">
+          <ToastNotice
+            closeLabel={t("cancel")}
+            message={errorMessage || successMessage}
+            tone={errorMessage ? "error" : "success"}
+            onClose={() => {
+              setErrorMessage("");
+              setSuccessMessage("");
+            }}
+          />
+        </div>
+      )}
 
       <ResourceFilterBar
         activeChips={activeFilterChips}
@@ -105,72 +117,13 @@ export default function PresetsPage() {
       />
 
       {filteredPresets.length > 0 ? (
-        <div className="grid gap-4 xl:grid-cols-2">
-          {filteredPresets.map((preset) => {
-            const meta = presetMeta(preset, context);
-            return (
-              <Card key={preset.id} className="group p-4 transition hover:border-panel-green/40">
-                <div className="flex items-start justify-between gap-4">
-                  <div className="flex min-w-0 items-start gap-3">
-                    <span className="flex size-10 shrink-0 items-center justify-center rounded-md border border-panel-line bg-slate-950/70 text-panel-green">
-                      <Bookmark aria-hidden="true" className="size-5" />
-                    </span>
-                    <div className="min-w-0">
-                      <h2 className="truncate font-semibold text-white">{preset.name}</h2>
-                      <p className="mt-1 truncate text-sm text-slate-400">{meta.gameName} · {meta.providerName}</p>
-                    </div>
-                  </div>
-                  <Badge className="shrink-0 bg-slate-800 text-slate-300">{preset.version || t("recommended")}</Badge>
-                </div>
-
-                <div className="mt-4 grid gap-2 sm:grid-cols-2">
-                  <DetailTile label={t("game")} value={meta.gameName} />
-                  <DetailTile label={t("serverType")} value={meta.providerName} />
-                  <DetailTile label={t("gameVersion")} value={preset.version || t("recommended")} />
-                  <DetailTile
-                    label={t("modsTitle")}
-                    value={preset.modIds.length > 0
-                      ? [meta.modPackName, t("selectedModsCount", { count: preset.modIds.length })].filter(Boolean).join(" · ")
-                      : t("none")}
-                  />
-                </div>
-
-                <div className="mt-4 flex flex-wrap gap-2 text-xs text-slate-400">
-                  <span className="inline-flex items-center gap-1 rounded border border-panel-line bg-slate-950/45 px-2 py-1">
-                    <Cpu aria-hidden="true" className="size-3.5 text-panel-green" />
-                    {t("cpuLimit")}: {formatCpuLimit(preset.cpuLimitCores, t)}
-                  </span>
-                  <span className="inline-flex items-center gap-1 rounded border border-panel-line bg-slate-950/45 px-2 py-1">
-                    <MemoryStick aria-hidden="true" className="size-3.5 text-panel-green" />
-                    {t("memoryLimit")}: {formatMemoryLimit(preset.memoryLimitMb, t)}
-                  </span>
-                  <span className="inline-flex items-center rounded border border-panel-line bg-slate-950/45 px-2 py-1">
-                    {t("modified")}: {localizeRelativeTime(preset.updatedAt, locale)}
-                  </span>
-                </div>
-
-                <div className="mt-4 flex flex-wrap items-center justify-between gap-3 border-t border-panel-line pt-3">
-                  <Link
-                    className="inline-flex h-9 items-center justify-center gap-2 rounded-md border border-panel-green/40 bg-panel-green/10 px-3 text-sm font-medium text-panel-green transition hover:bg-panel-green/15 focus:outline-none focus:ring-2 focus:ring-panel-green/50"
-                    href={`/servers/new?presetId=${encodeURIComponent(preset.id)}`}
-                  >
-                    <Plus aria-hidden="true" className="size-4" />
-                    {t("createServerFromPreset")}
-                  </Link>
-                  <Button
-                    className="h-9 text-red-200 hover:bg-red-500/15"
-                    variant="ghost"
-                    onClick={() => setPendingDelete(preset)}
-                    disabled={remove.isPending || presetsQuery.isError}
-                    aria-label={t("delete")}
-                  >
-                    <Trash2 aria-hidden="true" className="size-4" />
-                  </Button>
-                </div>
-              </Card>
-            );
-          })}
-        </div>
+        <PresetResourceTable
+          context={context}
+          locale={locale}
+          presets={filteredPresets}
+          onInspect={setSelectedPreset}
+          t={t}
+        />
       ) : null}
 
       {!presetsQuery.isLoading && filteredPresets.length === 0 && (
@@ -194,17 +147,168 @@ export default function PresetsPage() {
         onCancel={() => setPendingDelete(null)}
         onConfirm={() => pendingDelete && remove.mutate(pendingDelete.id)}
       />
+      {selectedPreset ? (
+        <PresetDetailsDrawer
+          context={context}
+          locale={locale}
+          preset={selectedPreset}
+          t={t}
+          onClose={() => setSelectedPreset(null)}
+          onDelete={() => {
+            setSelectedPreset(null);
+            setPendingDelete(selectedPreset);
+          }}
+        />
+      ) : null}
     </>
   );
 }
 
-function DetailTile({ label, value }: { label: string; value: string }) {
+function PresetResourceTable({
+  context,
+  locale,
+  presets,
+  onInspect,
+  t
+}: {
+  context: ReturnType<typeof buildPresetContext>;
+  locale: Locale;
+  presets: ConfigPreset[];
+  onInspect: (preset: ConfigPreset) => void;
+  t: (key: MessageKey, values?: Record<string, string | number>) => string;
+}) {
   return (
-    <div className="min-w-0 rounded-md border border-panel-line bg-slate-950/45 px-3 py-2">
-      <p className="text-xs text-slate-500">{label}</p>
-      <p className="mt-1 truncate text-sm font-medium text-slate-100">{value}</p>
+    <div className="overflow-hidden rounded-lg border border-panel-line bg-panel-card">
+      <div className="hidden overflow-x-auto md:block">
+        <table className="w-full min-w-[900px] border-collapse text-left text-sm">
+          <thead className="bg-slate-950/45 text-xs font-medium text-slate-500">
+            <tr>
+              <th className="px-4 py-3">{t("configurationPreset")}</th>
+              <th className="px-3 py-3">{t("serverType")}</th>
+              <th className="px-3 py-3">{t("gameVersion")}</th>
+              <th className="px-3 py-3">{t("runtimeResources")}</th>
+              <th className="px-3 py-3">{t("modsTitle")}</th>
+              <th className="px-3 py-3">{t("modified")}</th>
+              <th className="px-4 py-3 text-right">{t("actions")}</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-panel-line">
+            {presets.map((preset) => {
+              const meta = presetMeta(preset, context);
+              const modIds = preset.modIds ?? [];
+              return (
+                <tr className="group transition-colors hover:bg-slate-800/35" key={preset.id}>
+                  <td className="px-4 py-3">
+                    <button className="max-w-72 truncate text-left font-medium text-slate-100 group-hover:text-panel-green" onClick={() => onInspect(preset)} type="button">
+                      {preset.name}
+                    </button>
+                  </td>
+                  <td className="px-3 py-3">
+                    <p className="text-slate-200">{meta.gameName}</p>
+                    <p className="mt-0.5 text-xs text-slate-500">{meta.providerName}</p>
+                  </td>
+                  <td className="px-3 py-3"><Badge className="bg-slate-800 text-slate-300">{preset.version || t("recommended")}</Badge></td>
+                  <td className="px-3 py-3 font-mono text-xs text-slate-300">
+                    {formatCpuLimit(preset.cpuLimitCores, t)} · {formatMemoryLimit(preset.memoryLimitMb, t)}
+                  </td>
+                  <td className="px-3 py-3 text-slate-300">
+                    {modIds.length > 0 ? [meta.modPackName, t("selectedModsCount", { count: modIds.length })].filter(Boolean).join(" · ") : t("none")}
+                  </td>
+                  <td className="px-3 py-3 text-slate-400">{localizeRelativeTime(preset.updatedAt, locale)}</td>
+                  <td className="px-4 py-3">
+                    <div className="flex justify-end gap-2">
+                      <Button className="h-8 px-2.5 text-xs" variant="ghost" onClick={() => onInspect(preset)}>
+                        <Eye aria-hidden="true" className="size-3.5" />{t("viewDetails")}
+                      </Button>
+                      <Link className="inline-flex h-8 items-center gap-1.5 rounded-md border border-panel-green/35 bg-panel-green/10 px-2.5 text-xs font-medium text-panel-green hover:bg-panel-green/15" href={`/servers/new?presetId=${encodeURIComponent(preset.id)}`}>
+                        <Plus aria-hidden="true" className="size-3.5" />{t("createServer")}
+                      </Link>
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+      <div className="divide-y divide-panel-line md:hidden">
+        {presets.map((preset) => {
+          const meta = presetMeta(preset, context);
+          const modIds = preset.modIds ?? [];
+          return (
+            <button className="block w-full px-4 py-4 text-left hover:bg-slate-800/35" key={preset.id} onClick={() => onInspect(preset)} type="button">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="truncate font-medium text-slate-100">{preset.name}</p>
+                  <p className="mt-1 truncate text-xs text-slate-500">{meta.gameName} · {meta.providerName}</p>
+                </div>
+                <Badge className="shrink-0 bg-slate-800 text-slate-300">{preset.version || t("recommended")}</Badge>
+              </div>
+              <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs text-slate-400">
+                <span>{formatCpuLimit(preset.cpuLimitCores, t)} · {formatMemoryLimit(preset.memoryLimitMb, t)}</span>
+                <span>{modIds.length > 0 ? t("selectedModsCount", { count: modIds.length }) : t("none")}</span>
+                <span>{localizeRelativeTime(preset.updatedAt, locale)}</span>
+              </div>
+            </button>
+          );
+        })}
+      </div>
     </div>
   );
+}
+
+function PresetDetailsDrawer({
+  context,
+  locale,
+  preset,
+  t,
+  onClose,
+  onDelete
+}: {
+  context: ReturnType<typeof buildPresetContext>;
+  locale: Locale;
+  preset: ConfigPreset;
+  t: (key: MessageKey, values?: Record<string, string | number>) => string;
+  onClose: () => void;
+  onDelete: () => void;
+}) {
+  const meta = presetMeta(preset, context);
+  const modIds = preset.modIds ?? [];
+  const mods = modIds.length > 0 ? [meta.modPackName, t("selectedModsCount", { count: modIds.length })].filter(Boolean).join(" · ") : t("none");
+  return (
+    <div className="fixed inset-0 z-50 bg-slate-950/60" onMouseDown={(event) => event.target === event.currentTarget && onClose()} role="presentation">
+      <aside aria-label={t("configurationPreset")} className="ml-auto flex h-full w-full max-w-lg flex-col border-l border-panel-line bg-panel-card shadow-2xl">
+        <div className="flex items-start justify-between gap-4 border-b border-panel-line px-5 py-4">
+          <div className="min-w-0">
+            <p className="text-xs text-slate-500">{t("configurationPreset")}</p>
+            <h2 className="mt-1 truncate text-lg font-semibold text-white">{preset.name}</h2>
+          </div>
+          <button aria-label={t("cancel")} className="rounded-md p-2 text-slate-400 hover:bg-slate-800 hover:text-white" onClick={onClose} type="button"><X aria-hidden="true" className="size-5" /></button>
+        </div>
+        <div className="flex-1 overflow-y-auto px-5 py-5">
+          <dl className="divide-y divide-panel-line border-y border-panel-line">
+            <DrawerRow label={t("game")} value={meta.gameName} />
+            <DrawerRow label={t("serverType")} value={meta.providerName} />
+            <DrawerRow label={t("gameVersion")} value={preset.version || t("recommended")} />
+            <DrawerRow label={t("cpuLimit")} value={formatCpuLimit(preset.cpuLimitCores, t)} />
+            <DrawerRow label={t("memoryLimit")} value={formatMemoryLimit(preset.memoryLimitMb, t)} />
+            <DrawerRow label={t("modsTitle")} value={mods} />
+            <DrawerRow label={t("modified")} value={localizeRelativeTime(preset.updatedAt, locale)} />
+          </dl>
+        </div>
+        <div className="flex items-center justify-between gap-3 border-t border-panel-line px-5 py-4">
+          <Button className="text-red-200 hover:bg-red-500/15" variant="ghost" onClick={onDelete}><Trash2 aria-hidden="true" />{t("delete")}</Button>
+          <Link className="inline-flex h-10 items-center gap-2 rounded-md bg-panel-green px-4 text-sm font-semibold text-slate-950 hover:bg-panel-green/90" href={`/servers/new?presetId=${encodeURIComponent(preset.id)}`}>
+            <Plus aria-hidden="true" className="size-4" />{t("createServerFromPreset")}
+          </Link>
+        </div>
+      </aside>
+    </div>
+  );
+}
+
+function DrawerRow({ label, value }: { label: string; value: string }) {
+  return <div className="grid grid-cols-[9rem_minmax(0,1fr)] gap-4 py-3 text-sm"><dt className="text-slate-500">{label}</dt><dd className="text-right text-slate-100">{value}</dd></div>;
 }
 
 function filterOptionLabel<T extends string>(

--- a/apps/web/app/servers/page.tsx
+++ b/apps/web/app/servers/page.tsx
@@ -1,11 +1,14 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
+import Link from "next/link";
+import { Plus } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { PageHeader } from "@/components/page-header";
 import { ResourceFilterBar } from "@/components/resource-filter-bar";
-import { ServerCard } from "@/components/server-card";
-import { listGameServers, listGames } from "@/lib/api";
+import { ServerResourceTable } from "@/components/server-resource-table";
+import { Button } from "@/components/ui";
+import { getObservabilityMetrics, getSettings, listGameServers, listGames } from "@/lib/api";
 import { gameFilterOptions } from "@/lib/game-filters";
 import { useI18n } from "@/lib/i18n";
 import type { MessageKey } from "@/lib/i18n";
@@ -21,6 +24,8 @@ const statusFilters = [
 export default function ServersPage() {
   const query = useQuery({ queryKey: ["game-servers"], queryFn: listGameServers, retry: false, refetchInterval: 5000 });
   const gamesQuery = useQuery({ queryKey: ["games"], queryFn: listGames, retry: false, staleTime: 5 * 60 * 1000 });
+  const metricsQuery = useQuery({ queryKey: ["observability-metrics"], queryFn: getObservabilityMetrics, retry: false, refetchInterval: 5000 });
+  const settingsQuery = useQuery({ queryKey: ["settings"], queryFn: getSettings, retry: false, staleTime: 5 * 60 * 1000 });
   const { t } = useI18n();
   const [gameFilter, setGameFilter] = useState<ServerGameFilter>("all");
   const [statusFilter, setStatusFilter] = useState<ServerStatusFilter>("all");
@@ -54,7 +59,10 @@ export default function ServersPage() {
   ].filter(Boolean);
   return (
     <>
-      <PageHeader title={t("serversTitle")} />
+      <PageHeader
+        title={t("serversTitle")}
+        action={<Link href="/servers/new"><Button className="h-10 px-4"><Plus aria-hidden="true" className="size-4" />{t("createServer")}</Button></Link>}
+      />
       <ResourceFilterBar
         activeChips={activeFilterChips}
         clearLabel={t("clearFilters")}
@@ -76,9 +84,7 @@ export default function ServersPage() {
         searchPlaceholder={t("searchServers")}
       />
       {query.isError && <p className="mb-4 text-sm text-panel-gold">{t("apiServersUnavailable")}</p>}
-      <div className="grid gap-4 xl:grid-cols-2">
-        {filteredServers.map((server) => <ServerCard key={server.id} server={server} />)}
-      </div>
+      {filteredServers.length > 0 ? <ServerResourceTable servers={filteredServers} metrics={metricsQuery.data?.servers} publicHost={settingsQuery.data?.publicHost} /> : null}
       {filteredServers.length === 0 && <p className="mt-6 text-sm text-slate-400">{query.isLoading ? t("loading") : t("noServersMatch")}</p>}
     </>
   );

--- a/apps/web/components/app-shell.tsx
+++ b/apps/web/components/app-shell.tsx
@@ -3,13 +3,13 @@
 import Link from "next/link";
 import Image from "next/image";
 import { usePathname, useRouter } from "next/navigation";
-import { Activity, Archive, Bookmark, Box, Ellipsis, Gauge, Gamepad2, Globe2, HardDrive, KeyRound, Languages, LogOut, PackageCheck, Plus, Search, Settings, ShieldCheck, UserCog, X } from "lucide-react";
+import { Activity, Archive, Bookmark, Box, Ellipsis, Gauge, Gamepad2, Globe2, HardDrive, KeyRound, Languages, LogOut, PackageCheck, Search, Settings, UserCog, X } from "lucide-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useRef, useState, type FormEvent, type ReactNode } from "react";
 import { useI18n, type Locale } from "@/lib/i18n";
 import { cn } from "@/lib/utils";
 import { Button, Input } from "@/components/ui";
-import { changeAdminPassword, getApiHealth, getAuthBootstrap, getSettings, listGameServers, logoutAdmin, updateLocale } from "@/lib/api";
+import { changeAdminPassword, getAuthBootstrap, getSettings, listGameServers, logoutAdmin, updateLocale } from "@/lib/api";
 import { showWorldAndBackupFeatures } from "@/lib/feature-flags";
 import { gameServerJoinPort, gameServerMode, gameServerSearchText, gameServerWorldName } from "@/lib/game-server-resource";
 import { serverProviderDisplay, serverResourceLabelKey } from "@/lib/server-display";
@@ -17,8 +17,8 @@ import type { GameServerResource } from "@/lib/types";
 
 const nav = [
   { href: "/dashboard", labelKey: "navDashboard", icon: Gauge },
-  { href: "/games", labelKey: "navGames", icon: Gamepad2 },
   { href: "/servers", labelKey: "navServers", icon: HardDrive },
+  { href: "/games", labelKey: "navGames", icon: Gamepad2 },
   { href: "/worlds", labelKey: "navWorlds", icon: Globe2 },
   { href: "/mods", labelKey: "navMods", icon: Box },
   { href: "/presets", labelKey: "navPresets", icon: Bookmark },
@@ -29,6 +29,13 @@ const nav = [
 ] as const;
 
 const visibleNav = nav.filter((item) => showWorldAndBackupFeatures || (item.href !== "/worlds" && item.href !== "/backups"));
+
+const navGroups = [
+  { labelKey: "navOverviewGroup", hrefs: ["/dashboard"] },
+  { labelKey: "navResourcesGroup", hrefs: ["/servers", "/games", "/worlds", "/mods", "/presets", "/backups"] },
+  { labelKey: "navOperationsGroup", hrefs: ["/activity", "/versions"] },
+  { labelKey: "navSystemGroup", hrefs: ["/settings"] }
+] as const;
 
 export function AppShell({ children }: { children: ReactNode }) {
   const pathname = usePathname();
@@ -43,7 +50,6 @@ function AppChrome({ children }: { children: ReactNode }) {
   const router = useRouter();
   const queryClient = useQueryClient();
   const { locale, setLocale, t } = useI18n();
-  const [createPending, setCreatePending] = useState(false);
   const [search, setSearch] = useState("");
   const [searchOpen, setSearchOpen] = useState(false);
   const [profileOpen, setProfileOpen] = useState(false);
@@ -56,7 +62,6 @@ function AppChrome({ children }: { children: ReactNode }) {
   const [accountMessage, setAccountMessage] = useState("");
   const searchRef = useRef<HTMLFormElement>(null);
   const profileRef = useRef<HTMLDivElement>(null);
-  const apiHealth = useQuery({ queryKey: ["api-health"], queryFn: getApiHealth, retry: false, refetchInterval: 10000 });
   const authQuery = useQuery({ queryKey: ["auth-bootstrap"], queryFn: getAuthBootstrap, retry: false, staleTime: 30000 });
   const settingsQuery = useQuery({ queryKey: ["settings"], queryFn: getSettings, retry: false, staleTime: 30000 });
   const serversQuery = useQuery({ queryKey: ["game-servers"], queryFn: listGameServers, retry: false, enabled: searchOpen || search.trim().length > 0 });
@@ -88,8 +93,6 @@ function AppChrome({ children }: { children: ReactNode }) {
     },
     onError: (err) => setAccountMessage(err instanceof Error ? err.message : t("passwordChangeFailed"))
   });
-  const serviceAvailable = apiHealth.data?.status === "ok";
-  const serviceLabel = serviceAvailable ? t("online") : apiHealth.isLoading ? t("dockerCheckingShort") : t("unavailable");
   const searchTerm = search.trim().toLowerCase();
   const searchResults = useMemo(() => {
     if (!searchTerm) return [];
@@ -104,16 +107,9 @@ function AppChrome({ children }: { children: ReactNode }) {
   }, [searchTerm, serversQuery.data, t]);
 
   useEffect(() => {
-    setCreatePending(false);
     setProfileOpen(false);
     setMobileMoreOpen(false);
   }, [pathname]);
-
-  useEffect(() => {
-    if (!createPending) return;
-    const timeout = window.setTimeout(() => setCreatePending(false), 2000);
-    return () => window.clearTimeout(timeout);
-  }, [createPending]);
 
   useEffect(() => {
     visibleNav.forEach((item) => router.prefetch(item.href));
@@ -201,23 +197,34 @@ function AppChrome({ children }: { children: ReactNode }) {
           </span>
           <span className="font-semibold">GamePanel Lite</span>
         </Link>
-        <nav className="flex flex-1 flex-col gap-1 px-3 py-4">
-          {visibleNav.map((item) => {
-            const active = pathname === item.href || pathname.startsWith(`${item.href}/`);
-            const Icon = item.icon;
+        <nav className="flex flex-1 flex-col gap-5 overflow-y-auto px-3 py-4">
+          {navGroups.map((group) => {
+            const items = visibleNav.filter((item) => group.hrefs.some((href) => href === item.href));
+            if (items.length === 0) return null;
             return (
-              <Link
-                key={item.href}
-                href={item.href}
-                onMouseEnter={() => router.prefetch(item.href)}
-                className={cn(
-                  "flex items-center gap-3 rounded-md px-3 py-3 text-sm text-slate-300 transition hover:bg-slate-800 hover:text-white",
-                  active && "bg-slate-800/80 text-white"
-                )}
-              >
-                <Icon aria-hidden="true" />
-                {t(item.labelKey)}
-              </Link>
+              <div key={group.labelKey}>
+                <p className="mb-1 px-3 text-[11px] font-medium text-slate-600">{t(group.labelKey)}</p>
+                <div className="space-y-0.5">
+                  {items.map((item) => {
+                    const active = pathname === item.href || pathname.startsWith(`${item.href}/`);
+                    const Icon = item.icon;
+                    return (
+                      <Link
+                        key={item.href}
+                        href={item.href}
+                        onMouseEnter={() => router.prefetch(item.href)}
+                        className={cn(
+                          "flex items-center gap-3 rounded-md px-3 py-2.5 text-sm text-slate-300 transition hover:bg-slate-800 hover:text-white",
+                          active && "bg-slate-800/80 text-white"
+                        )}
+                      >
+                        <Icon aria-hidden="true" className="size-5" />
+                        {t(item.labelKey)}
+                      </Link>
+                    );
+                  })}
+                </div>
+              </div>
             );
           })}
         </nav>
@@ -270,29 +277,6 @@ function AppChrome({ children }: { children: ReactNode }) {
               )}
             </form>
             <div className="ml-auto flex shrink-0 items-center gap-3">
-              <div className="hidden shrink-0 items-center gap-2 text-xs text-slate-300 sm:flex">
-                <span
-                  className={cn(
-                    "inline-flex items-center gap-1 whitespace-nowrap rounded border border-panel-line bg-slate-950/45 px-2 py-1",
-                    serviceAvailable ? "text-panel-green" : "text-panel-gold"
-                  )}
-                >
-                  <ShieldCheck aria-hidden="true" className="size-4" />
-                  <span>{serviceLabel}</span>
-                </span>
-              </div>
-              <Link
-                href="/servers/new"
-                aria-label={t("createServer")}
-                className="shrink-0"
-                onClick={() => setCreatePending(true)}
-                onMouseEnter={() => router.prefetch("/servers/new")}
-              >
-                <Button className="h-11 w-11 shrink-0 whitespace-nowrap sm:h-12 sm:w-44">
-                  <Plus aria-hidden="true" />
-                  <span className="hidden sm:inline">{createPending ? t("openingCreateServer") : t("createServer")}</span>
-                </Button>
-              </Link>
               <div ref={profileRef} className="relative hidden md:block">
                 <button
                   type="button"

--- a/apps/web/components/dashboard-charts.tsx
+++ b/apps/web/components/dashboard-charts.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import ReactECharts from "echarts-for-react";
+import type { EChartsOption } from "echarts";
+import type { MetricSeries } from "@/features/monitoring/types";
+
+export function ResourceTrendChart({ emptyLabel, series }: { emptyLabel: string; series?: MetricSeries }) {
+  const points = series?.points ?? [];
+
+  if (points.length < 2) {
+    return <div className="flex h-[260px] items-center justify-center text-sm text-slate-500">{emptyLabel}</div>;
+  }
+
+  const color = chartColor(series?.key);
+  const option: EChartsOption = {
+    animationDuration: 180,
+    animationEasing: "quarticOut",
+    backgroundColor: "transparent",
+    color: [color],
+    grid: { bottom: 18, containLabel: true, left: 6, right: 12, top: 18 },
+    tooltip: {
+      trigger: "axis",
+      axisPointer: { lineStyle: { color: "rgba(148,163,184,.35)", type: "dashed" } },
+      backgroundColor: "#0b111a",
+      borderColor: "#334155",
+      borderWidth: 1,
+      confine: true,
+      formatter: (params) => {
+        const item = Array.isArray(params) ? params[0] : params;
+        const raw = item?.value;
+        const pair = Array.isArray(raw) ? raw : [];
+        const timestamp = typeof pair[0] === "string" || typeof pair[0] === "number" ? new Date(pair[0]) : null;
+        const value = Number(pair[1]);
+        const time = timestamp && !Number.isNaN(timestamp.getTime()) ? timestamp.toLocaleString() : "";
+        return `${time}<br/><strong>${formatMetricValue(value, series?.unit ?? "")}</strong>`;
+      }
+    },
+    xAxis: {
+      axisLabel: { color: "#64748b", hideOverlap: true, margin: 12 },
+      axisLine: { lineStyle: { color: "rgba(100,116,139,.35)" } },
+      axisTick: { show: false },
+      boundaryGap: false,
+      type: "time"
+    } as unknown as EChartsOption["xAxis"],
+    yAxis: {
+      axisLabel: { color: "#64748b", formatter: (value: number) => compactMetricValue(value, series?.unit ?? ""), margin: 10 },
+      axisLine: { show: false },
+      axisTick: { show: false },
+      min: 0,
+      splitLine: { lineStyle: { color: "rgba(148,163,184,.11)" } },
+      type: "value"
+    },
+    series: [{
+      areaStyle: { color, opacity: 0.06 },
+      data: points.map((point) => [point.timestamp, point.value]),
+      lineStyle: { color, width: 2 },
+      name: series?.title,
+      showSymbol: false,
+      smooth: 0.18,
+      symbol: "circle",
+      type: "line"
+    }]
+  };
+
+  return <ReactECharts notMerge option={option} opts={{ renderer: "canvas" }} style={{ height: 260, width: "100%" }} />;
+}
+
+function chartColor(key?: string) {
+  if (key === "nodeMemory") return "#a78bfa";
+  if (key === "nodeNetwork") return "#60a5fa";
+  return "#59d46f";
+}
+
+function formatMetricValue(value: number, unit: string) {
+  if (!Number.isFinite(value)) return "—";
+  if (unit === "%") return `${value.toFixed(1)}%`;
+  if (unit === "MB") return value >= 1024 ? `${(value / 1024).toFixed(1)} GB` : `${value.toFixed(0)} MB`;
+  if (unit === "MB/s") return `${value.toFixed(2)} MB/s`;
+  return `${value.toFixed(1)} ${unit}`.trim();
+}
+
+function compactMetricValue(value: number, unit: string) {
+  if (unit === "%") return `${value}%`;
+  if (unit === "MB" && value >= 1024) return `${(value / 1024).toFixed(1)}G`;
+  return `${value}${unit ? ` ${unit}` : ""}`;
+}

--- a/apps/web/components/server-actions.tsx
+++ b/apps/web/components/server-actions.tsx
@@ -3,6 +3,7 @@
 import { Copy, Ellipsis, Globe2, Play, RotateCcw, Square, Trash2, X } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { usePathname, useRouter } from "next/navigation";
+import { createPortal } from "react-dom";
 import { useEffect, useRef, useState } from "react";
 import { Button, ToastNotice } from "@/components/ui";
 import { serverActionRedirectPath } from "@/lib/server-action-flow";
@@ -20,6 +21,7 @@ export function ServerActions({
   showInvite = true,
   showDelete = true,
   compact = false,
+  rowMode = false,
   disabled = false,
   regenerationBusy = false,
   onRegenerateWorld,
@@ -29,6 +31,7 @@ export function ServerActions({
   showInvite?: boolean;
   showDelete?: boolean;
   compact?: boolean;
+  rowMode?: boolean;
   disabled?: boolean;
   regenerationBusy?: boolean;
   onRegenerateWorld?: () => void;
@@ -44,11 +47,14 @@ export function ServerActions({
   const [errorMessage, setErrorMessage] = useState("");
   const [successMessage, setSuccessMessage] = useState("");
   const [moreOpen, setMoreOpen] = useState(false);
+  const [morePosition, setMorePosition] = useState({ left: 0, top: 0 });
   const noticeTimerRef = useRef<number | null>(null);
-  const moreRef = useRef<HTMLDetailsElement>(null);
+  const moreButtonRef = useRef<HTMLButtonElement>(null);
+  const moreMenuRef = useRef<HTMLDivElement>(null);
   const status = gameServerStatus(server);
   const lifecycleBusy = status === "creating" || status === "starting" || status === "stopping" || status === "restarting" || status === "deleting";
   const controlsDisabled = disabled || Boolean(busyAction) || lifecycleBusy;
+  const showRowRestart = rowMode && status === "running";
   const actionLabel = (action: "start" | "stop" | "restart" | "delete") =>
     action === "start" ? t("actionStart") : action === "stop" ? t("actionStop") : action === "restart" ? t("actionRestart") : t("delete");
   const successLabel = (action: "start" | "stop" | "restart" | "delete") =>
@@ -72,18 +78,43 @@ export function ServerActions({
   useEffect(() => {
     if (!moreOpen) return;
     const closeMenu = (event: PointerEvent) => {
-      if (!moreRef.current?.contains(event.target as Node)) setMoreOpen(false);
+      const target = event.target as Node;
+      if (!moreButtonRef.current?.contains(target) && !moreMenuRef.current?.contains(target)) setMoreOpen(false);
     };
     const closeOnEscape = (event: KeyboardEvent) => {
       if (event.key === "Escape") setMoreOpen(false);
     };
+    const closeOnViewportChange = () => setMoreOpen(false);
     document.addEventListener("pointerdown", closeMenu);
     window.addEventListener("keydown", closeOnEscape);
+    window.addEventListener("resize", closeOnViewportChange);
+    window.addEventListener("scroll", closeOnViewportChange, true);
     return () => {
       document.removeEventListener("pointerdown", closeMenu);
       window.removeEventListener("keydown", closeOnEscape);
+      window.removeEventListener("resize", closeOnViewportChange);
+      window.removeEventListener("scroll", closeOnViewportChange, true);
     };
   }, [moreOpen]);
+
+  const toggleMoreMenu = () => {
+    if (controlsDisabled) return;
+    if (moreOpen) {
+      setMoreOpen(false);
+      return;
+    }
+    const rect = moreButtonRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const menuWidth = 144;
+    const visibleActionCount = Number(showRowRestart) + Number(Boolean(onRegenerateWorld)) + Number(showDelete);
+    const hasSeparatedDelete = showDelete && (showRowRestart || Boolean(onRegenerateWorld));
+    const estimatedHeight = visibleActionCount * 32 + 8 + (hasSeparatedDelete ? 9 : 0);
+    setMorePosition({
+      left: Math.max(8, Math.min(window.innerWidth - menuWidth - 8, rect.right - menuWidth)),
+      top: rect.bottom + estimatedHeight + 6 <= window.innerHeight ? rect.bottom + 6 : Math.max(8, rect.top - estimatedHeight - 6)
+    });
+    setMoreOpen(true);
+  };
 
   useEffect(() => {
     return () => {
@@ -154,11 +185,15 @@ export function ServerActions({
   };
 
   const pendingLabel = pendingAction ? actionLabel(pendingAction) : "";
-  const buttonClassName = compact ? "h-10 w-full min-w-0 whitespace-nowrap px-2 text-sm" : undefined;
+  const buttonClassName = rowMode
+    ? "h-8 min-w-0 whitespace-nowrap px-2.5 text-xs"
+    : compact
+      ? "h-10 w-full min-w-0 whitespace-nowrap px-2 text-sm"
+      : undefined;
 
   return (
     <>
-      <div className={cn(compact ? "grid grid-cols-2 gap-2 md:grid-cols-4" : "flex flex-wrap gap-2", className)}>
+      <div className={cn(rowMode ? "flex flex-nowrap justify-end gap-1.5" : compact ? "grid grid-cols-2 gap-2 md:grid-cols-4" : "flex flex-wrap gap-2", className)}>
         {status === "running" || status === "stopping" ? (
           <Button className={buttonClassName} variant="danger" onClick={() => runAction("stop")} disabled={controlsDisabled}>
             <Square aria-hidden="true" />
@@ -178,69 +213,94 @@ export function ServerActions({
             {startLabel}
           </Button>
         )}
-        <Button className={buttonClassName} variant="secondary" onClick={() => runAction("restart")} disabled={controlsDisabled}>
-          <RotateCcw aria-hidden="true" />
-          {restartLabel}
-        </Button>
+        {!rowMode ? (
+          <Button className={buttonClassName} variant="secondary" onClick={() => runAction("restart")} disabled={controlsDisabled}>
+            <RotateCcw aria-hidden="true" />
+            {restartLabel}
+          </Button>
+        ) : null}
         {showInvite && (
           <Button className={buttonClassName} variant="secondary" onClick={() => void copyInvite()} disabled={status === "deleting"}>
             <Copy aria-hidden="true" />
             {copiedInvite ? t("copied") : t("actionCopyInvite")}
           </Button>
         )}
-        {onRegenerateWorld || showDelete ? (
-          <details
-            ref={moreRef}
-            className={cn("relative", compact && "col-span-2 md:col-span-1")}
-            open={moreOpen}
-            onToggle={(event) => setMoreOpen(event.currentTarget.open)}
+        {rowMode || onRegenerateWorld || showDelete ? (
+          <button
+            aria-expanded={moreOpen}
+            aria-haspopup="menu"
+            aria-label={t("serverMoreActions")}
+            className={cn(
+              "flex items-center justify-center rounded-md border border-panel-line bg-transparent text-slate-400 transition hover:border-slate-600 hover:bg-slate-800 hover:text-white focus:outline-none focus-visible:ring-1 focus-visible:ring-slate-500",
+              moreOpen && "border-slate-600 bg-slate-800 text-white",
+              rowMode ? "size-8 px-0" : "h-10 px-3",
+              compact && !rowMode && "col-span-2 w-full md:col-span-1",
+              controlsDisabled && "cursor-not-allowed opacity-50"
+            )}
+            disabled={controlsDisabled}
+            onClick={toggleMoreMenu}
+            ref={moreButtonRef}
+            title={t("serverMoreActions")}
+            type="button"
           >
-            <summary
-              aria-label={t("serverMoreActions")}
-              className={cn(
-                "flex h-10 cursor-pointer list-none items-center justify-center rounded-md border border-panel-line bg-slate-900/70 px-3 text-slate-100 transition hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-panel-green/50 [&::-webkit-details-marker]:hidden",
-                compact && "w-full",
-                controlsDisabled && "cursor-not-allowed opacity-50"
-              )}
-              onClick={(event) => {
-                if (controlsDisabled) event.preventDefault();
-              }}
-              title={t("serverMoreActions")}
-            >
-              <Ellipsis aria-hidden="true" className="size-4" />
-            </summary>
-            <div className="absolute right-0 top-12 z-30 min-w-52 rounded-md border border-panel-line bg-slate-950 p-1.5 shadow-[0_8px_16px_rgba(0,0,0,0.35)]">
+            <Ellipsis aria-hidden="true" className="size-4" />
+          </button>
+        ) : null}
+      </div>
+      {moreOpen && typeof document !== "undefined" ? createPortal(
+        <div
+          className="fixed z-[70] w-36 rounded-md border border-slate-700/80 bg-slate-900 p-1 shadow-[0_4px_8px_rgba(0,0,0,0.38)]"
+          ref={moreMenuRef}
+          role="menu"
+          style={{ left: morePosition.left, top: morePosition.top }}
+        >
+              {showRowRestart ? (
+                <button
+                  className="flex h-8 w-full items-center gap-2 rounded-sm px-2.5 text-left text-[13px] text-slate-200 transition hover:bg-slate-800 focus:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-slate-500 disabled:cursor-not-allowed disabled:opacity-50"
+                  disabled={controlsDisabled}
+                  onClick={() => {
+                    setMoreOpen(false);
+                    runAction("restart");
+                  }}
+                  role="menuitem"
+                  type="button"
+                >
+                  <RotateCcw aria-hidden="true" className="size-3.5 text-slate-400" />
+                  {restartLabel}
+                </button>
+              ) : null}
               {onRegenerateWorld ? <button
-                className="flex w-full items-center gap-2 rounded px-3 py-2 text-left text-sm text-panel-gold transition hover:bg-panel-gold/10 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-panel-gold/40 disabled:cursor-not-allowed disabled:opacity-50"
+                className="flex h-8 w-full items-center gap-2 rounded-sm px-2.5 text-left text-[13px] text-panel-gold transition hover:bg-panel-gold/10 focus:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-panel-gold/60 disabled:cursor-not-allowed disabled:opacity-50"
                 disabled={controlsDisabled || regenerationBusy}
                 onClick={() => {
                   setMoreOpen(false);
                   onRegenerateWorld();
                 }}
+                role="menuitem"
                 type="button"
               >
-                <Globe2 aria-hidden="true" className="size-4" />
+                <Globe2 aria-hidden="true" className="size-3.5" />
                 {regenerationBusy ? t("worldRegenerationProgress") : t("worldRegenerateAction")}
               </button> : null}
-              {showDelete && onRegenerateWorld ? <div className="my-1 border-t border-panel-line" /> : null}
+              {showDelete && (onRegenerateWorld || showRowRestart) ? <div className="mx-2 my-1 border-t border-white/10" /> : null}
               {showDelete ? (
                 <button
-                  className="flex w-full items-center gap-2 rounded px-3 py-2 text-left text-sm text-red-200 transition hover:bg-red-400/10 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-red-400/40 disabled:cursor-not-allowed disabled:opacity-50"
+                  className="flex h-8 w-full items-center gap-2 rounded-sm px-2.5 text-left text-[13px] text-red-300 transition hover:bg-red-400/10 focus:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-red-400/60 disabled:cursor-not-allowed disabled:opacity-50"
                   disabled={controlsDisabled}
                   onClick={() => {
                     setMoreOpen(false);
                     runAction("delete");
                   }}
+                  role="menuitem"
                   type="button"
                 >
-                  <Trash2 aria-hidden="true" className="size-4" />
+                  <Trash2 aria-hidden="true" className="size-3.5" />
                   {deleteLabel}
                 </button>
               ) : null}
-            </div>
-          </details>
-        ) : null}
-      </div>
+        </div>,
+        document.body
+      ) : null}
       {(errorMessage || successMessage) && (
         <div className="pointer-events-none fixed inset-x-4 bottom-4 z-[60] flex justify-end md:inset-x-auto md:bottom-auto md:right-6 md:top-24">
           <ToastNotice

--- a/apps/web/components/server-card.tsx
+++ b/apps/web/components/server-card.tsx
@@ -40,7 +40,13 @@ export function ServerCard({ server, compact = false }: { server: GameServerReso
                 <ServerStatusBadge status={status} />
               </div>
             </div>
-            <PlayerPill label={t("players")} players={players} maxPlayers={maxPlayers} running={status === "running"} unavailableLabel={t("unavailable")} />
+            <PlayerPill
+              label={t("players")}
+              players={players}
+              maxPlayers={maxPlayers}
+              running={status === "running"}
+              unavailableHint={t("playerStatsUnavailableHint")}
+            />
           </div>
           <div className="grid gap-2 sm:grid-cols-2">
             <InfoTile label={t("version")} value={version} />
@@ -57,20 +63,25 @@ export function ServerCard({ server, compact = false }: { server: GameServerReso
   );
 }
 
-function PlayerPill({ label, maxPlayers, players, running, unavailableLabel }: { label: string; maxPlayers: number; players?: number; running: boolean; unavailableLabel: string }) {
+function PlayerPill({ label, maxPlayers, players, running, unavailableHint }: { label: string; maxPlayers: number; players?: number; running: boolean; unavailableHint: string }) {
+  const hasPlayerData = typeof players === "number";
   return (
     <div
       className={cn(
         "flex w-full items-center justify-between gap-3 rounded-md border bg-slate-950/35 px-3 py-2 lg:w-auto lg:min-w-32",
-        running ? "border-panel-green/30 text-panel-green" : "border-panel-line text-slate-300"
+        running && hasPlayerData ? "border-panel-green/30 text-panel-green" : "border-panel-line text-slate-300"
       )}
     >
       <div className="flex items-center gap-2 text-xs font-medium text-slate-400">
-        <Users aria-hidden="true" className={cn("size-4", running ? "text-panel-green" : "text-slate-500")} />
+        <Users aria-hidden="true" className={cn("size-4", running && hasPlayerData ? "text-panel-green" : "text-slate-500")} />
         {label}
       </div>
-      <p className="whitespace-nowrap text-sm font-semibold text-white">
-        {typeof players === "number" ? `${players} / ${maxPlayers}` : unavailableLabel}
+      <p
+        aria-label={hasPlayerData ? undefined : unavailableHint}
+        className={cn("whitespace-nowrap text-sm font-semibold", hasPlayerData ? "text-white" : "text-slate-500")}
+        title={hasPlayerData ? undefined : unavailableHint}
+      >
+        {hasPlayerData ? `${players} / ${maxPlayers}` : "—"}
       </p>
     </div>
   );

--- a/apps/web/components/server-game-art.tsx
+++ b/apps/web/components/server-game-art.tsx
@@ -7,7 +7,7 @@ import { serverProviderDisplay } from "@/lib/server-display";
 import { cn } from "@/lib/utils";
 import type { GameKey, ProviderKey, ServerMode } from "@/lib/types";
 
-export function ServerGameArt({ server, className }: { server: { mode?: ServerMode; providerKey?: ProviderKey; gameKey?: GameKey }; className?: string }) {
+export function ServerGameArt({ server, className, compact = false }: { server: { mode?: ServerMode; providerKey?: ProviderKey; gameKey?: GameKey }; className?: string; compact?: boolean }) {
   const art = getGameArt(server.gameKey ?? server.providerKey);
   const provider = serverProviderDisplay(server);
   const showProviderMark = provider.label !== "Terraria";
@@ -40,7 +40,8 @@ export function ServerGameArt({ server, className }: { server: { mode?: ServerMo
         <span
           aria-label={provider.label}
           className={cn(
-            "absolute bottom-1 right-1 flex size-5 items-center justify-center rounded text-slate-950 shadow-[0_0_0_1px_rgba(255,255,255,0.18)]",
+            "absolute flex items-center justify-center text-slate-950 shadow-[0_0_0_1px_rgba(255,255,255,0.18)]",
+            compact ? "bottom-0.5 right-0.5 size-3.5 rounded-sm" : "bottom-1 right-1 size-5 rounded",
             provider.tone === "purple" ? "bg-purple-400/95" : "",
             provider.tone === "sky" ? "bg-sky-300/95" : "",
             provider.tone === "amber" ? "bg-panel-gold/95" : "",
@@ -49,7 +50,7 @@ export function ServerGameArt({ server, className }: { server: { mode?: ServerMo
           )}
           title={provider.label}
         >
-          {provider.tone === "purple" ? <Hammer aria-hidden="true" className="size-3" /> : <Box aria-hidden="true" className="size-3" />}
+          {provider.tone === "purple" ? <Hammer aria-hidden="true" className={compact ? "size-2" : "size-3"} /> : <Box aria-hidden="true" className={compact ? "size-2" : "size-3"} />}
         </span>
       )}
     </div>

--- a/apps/web/components/server-resource-table.tsx
+++ b/apps/web/components/server-resource-table.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import Link from "next/link";
+import { Plug, Users } from "lucide-react";
+import { ServerActions } from "@/components/server-actions";
+import { ServerGameArt } from "@/components/server-game-art";
+import { ServerProviderBadge, ServerStatusBadge } from "@/components/server-badges";
+import {
+  gameServerJoinPort,
+  gameServerMaxPlayers,
+  gameServerMode,
+  gameServerStatus,
+  gameServerVersion
+} from "@/lib/game-server-resource";
+import { useI18n } from "@/lib/i18n";
+import type { ObservabilityServerMetric } from "@/lib/api";
+import type { GameServerResource } from "@/lib/types";
+
+export function ServerResourceTable({
+  servers,
+  metrics = [],
+  showActions = true,
+  showVersion = true,
+  limit,
+  flat = false,
+  publicHost
+}: {
+  servers: GameServerResource[];
+  metrics?: ObservabilityServerMetric[];
+  showActions?: boolean;
+  showVersion?: boolean;
+  limit?: number;
+  flat?: boolean;
+  publicHost?: string;
+}) {
+  const { t } = useI18n();
+  const rows = typeof limit === "number" ? servers.slice(0, limit) : servers;
+  const metricMap = new Map(metrics.map((metric) => [metric.id, metric]));
+
+  return (
+    <div className={flat ? "overflow-hidden border-y border-panel-line" : "overflow-hidden rounded-lg border border-panel-line bg-panel-card"}>
+      <div className="hidden overflow-x-auto md:block">
+        <table className="w-full min-w-[880px] border-collapse text-left text-sm">
+          <thead className="bg-slate-950/45 text-xs font-medium text-slate-500">
+            <tr>
+              <th className="px-4 py-3">{t("server")}</th>
+              <th className="px-3 py-3">{t("serverType")}</th>
+              <th className="px-3 py-3">{t("status")}</th>
+              <th className="px-3 py-3">{t("players")}</th>
+              <th className="px-3 py-3">CPU</th>
+              <th className="px-3 py-3">{t("memory")}</th>
+              <th className="px-3 py-3">{t("serverAddress")}</th>
+              {showVersion ? <th className="px-3 py-3">{t("version")}</th> : null}
+              {showActions ? <th className="px-4 py-3 text-right">{t("actions")}</th> : null}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-panel-line">
+            {rows.map((server) => {
+              const metric = metricMap.get(server.id);
+              const status = gameServerStatus(server);
+              const players = server.status.playersOnline;
+              const maxPlayers = gameServerMaxPlayers(server);
+              const displayServer = { gameKey: server.gameKey, providerKey: server.providerKey, mode: gameServerMode(server) };
+              return (
+                <tr key={server.id} className="group bg-panel-card transition-colors hover:bg-slate-800/35">
+                  <td className="px-4 py-3">
+                    <Link className="flex min-w-0 items-center gap-3" href={`/servers/${server.id}`}>
+                      <ServerGameArt server={displayServer} className="size-9 rounded" compact />
+                      <span className="min-w-0">
+                        <span className="block max-w-64 truncate font-medium text-slate-100 group-hover:text-panel-green">{server.name}</span>
+                        <span className="mt-0.5 block text-xs text-slate-500">{server.id.slice(0, 8)}</span>
+                      </span>
+                    </Link>
+                  </td>
+                  <td className="px-3 py-3"><ServerProviderBadge server={displayServer} /></td>
+                  <td className="px-3 py-3"><ServerStatusBadge status={status} /></td>
+                  <td className="px-3 py-3 font-mono text-slate-300">
+                    {typeof players === "number" ? `${players}/${maxPlayers}` : <DataMissing />}
+                  </td>
+                  <td className="px-3 py-3 font-mono text-slate-300">{metric?.statsAvailable ? `${metric.cpuPercent.toFixed(1)}%` : <DataMissing />}</td>
+                  <td className="px-3 py-3 font-mono text-slate-300">{metric?.statsAvailable ? formatMemory(metric.memoryMb) : <DataMissing />}</td>
+                  <td className="px-3 py-3 font-mono text-slate-300">{formatAddress(publicHost, gameServerJoinPort(server))}</td>
+                  {showVersion ? <td className="px-3 py-3 text-slate-300">{gameServerVersion(server)}</td> : null}
+                  {showActions ? (
+                    <td className="px-4 py-3">
+                      <ServerActions server={server} rowMode showInvite={false} showDelete />
+                    </td>
+                  ) : null}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="divide-y divide-panel-line md:hidden">
+        {rows.map((server) => {
+          const metric = metricMap.get(server.id);
+          const status = gameServerStatus(server);
+          const players = server.status.playersOnline;
+          const maxPlayers = gameServerMaxPlayers(server);
+          const displayServer = { gameKey: server.gameKey, providerKey: server.providerKey, mode: gameServerMode(server) };
+          return (
+            <div key={server.id} className="px-4 py-4">
+              <div className="flex items-start gap-3">
+                <ServerGameArt server={displayServer} className="size-10 rounded" compact />
+                <div className="min-w-0 flex-1">
+                  <Link className="block truncate font-medium text-slate-100" href={`/servers/${server.id}`}>{server.name}</Link>
+                  <div className="mt-1.5 flex flex-wrap items-center gap-2">
+                    <ServerProviderBadge server={displayServer} />
+                    <ServerStatusBadge status={status} />
+                  </div>
+                </div>
+              </div>
+              <div className="mt-3 grid grid-cols-2 gap-x-4 gap-y-2 border-y border-panel-line py-3 text-xs">
+                <Metric label={t("players")} icon={<Users aria-hidden="true" className="size-3.5" />} value={typeof players === "number" ? `${players}/${maxPlayers}` : "—"} />
+                <Metric label="CPU" value={metric?.statsAvailable ? `${metric.cpuPercent.toFixed(1)}%` : "—"} />
+                <Metric label={t("memory")} value={metric?.statsAvailable ? formatMemory(metric.memoryMb) : "—"} />
+                <Metric label={t("serverAddress")} icon={<Plug aria-hidden="true" className="size-3.5" />} value={formatAddress(publicHost, gameServerJoinPort(server))} />
+              </div>
+              {showActions ? <div className="mt-3"><ServerActions server={server} rowMode showInvite={false} showDelete /></div> : null}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function DataMissing() {
+  return <span className="text-slate-600">—</span>;
+}
+
+function Metric({ icon, label, value }: { icon?: React.ReactNode; label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <span className="flex items-center gap-1.5 text-slate-500">{icon}{label}</span>
+      <span className="font-mono text-slate-200">{value}</span>
+    </div>
+  );
+}
+
+function formatMemory(value: number) {
+  return value >= 1024 ? `${(value / 1024).toFixed(1)} GB` : `${Math.round(value)} MB`;
+}
+
+function formatAddress(host: string | undefined, port: number) {
+  const normalizedHost = host?.trim();
+  if (!normalizedHost) return `:${port}`;
+  return normalizedHost.includes(":") && !normalizedHost.startsWith("[") ? `[${normalizedHost}]:${port}` : `${normalizedHost}:${port}`;
+}

--- a/apps/web/lib/i18n.tsx
+++ b/apps/web/lib/i18n.tsx
@@ -30,6 +30,10 @@ const messages = {
     navActivity: "监控",
     navVersions: "版本",
     navSettings: "设置",
+    navOverviewGroup: "概览",
+    navResourcesGroup: "资源",
+    navOperationsGroup: "运维",
+    navSystemGroup: "系统",
     userProfile: "用户资料",
     userAvatarAlt: "像素玩家头像",
     localUser: "本地玩家",
@@ -163,10 +167,26 @@ const messages = {
     english: "EN",
     dashboardTitle: "仪表盘",
     dashboardDescription: "集中管理你的游戏服务器。",
+    dashboardInfrastructureDescription: "基础设施与游戏服务器运行概览。",
+    dashboardSummary: "运行摘要",
+    dashboardAlerts: "告警",
+    dashboardResourceTrend: "资源使用趋势",
+    dashboardResourceTrendDescription: "宿主机资源历史指标，每 30 秒刷新。",
+    dashboardResourceMetric: "资源指标",
+    dashboardNetwork: "网络",
+    dashboardServerInstances: "服务器实例",
+    dashboardViewAll: "查看全部",
+    dashboardRecentEvents: "最近事件",
+    dashboardSystemStatus: "系统状态",
+    dashboardPanelService: "面板服务",
+    dashboardMetricsService: "监控数据",
+    dashboardStatusNormal: "正常",
+    dashboardOpenMonitoring: "打开监控中心",
     runningServers: "运行中的服务器",
     runningHint: "{count} 台运行中",
     onlinePlayers: "在线玩家",
     playersOnlineHint: "全部服务器容量",
+    playerStatsUnavailableHint: "当前游戏未提供玩家统计",
     latestBackup: "最新备份",
     storageUsed: "已用存储",
     storageHint: "GamePanel 数据目录总计",
@@ -180,6 +200,8 @@ const messages = {
     createBackupQuickHint: "进入服务器详情页创建",
     runtimeOverview: "运行监控",
     runtimeOverviewHint: "当前服务器资源占用概况",
+    serverStatusDistribution: "服务器状态构成",
+    statusTransitioning: "处理中",
     chooseWorldFileToImport: "请选择 `.wld` 世界文件导入。",
     createBackup: "创建备份",
     serversTitle: "服务器",
@@ -217,6 +239,7 @@ const messages = {
     resourceLimits: "资源限制",
     resourceLimitsHint: "设置服务器容器的 CPU 和内存上限，留空表示不限制。",
     runtimeResources: "运行资源",
+    viewDetails: "查看详情",
     runtimeResourcesHint: "容器 CPU / 内存上限与当前用量。",
     adjustResources: "调整资源",
     advancedRuntimeResources: "高级：运行资源",
@@ -1214,13 +1237,13 @@ const messages = {
     healthDegraded: "降级",
     healthDown: "不可用",
     connected: "已连接",
-    trendCpuTitle: "CPU Usage",
+    trendCpuTitle: "CPU 使用率",
     trendCpuNote: "CPU 使用趋势",
-    trendMemoryTitle: "Memory Usage",
+    trendMemoryTitle: "内存使用量",
     trendMemoryNote: "内存占用趋势",
-    trendPlayersTitle: "Player Count",
+    trendPlayersTitle: "在线玩家",
     trendPlayersNote: "在线玩家趋势",
-    trendEventsTitle: "Events",
+    trendEventsTitle: "事件数量",
     trendEventsNote: "最近事件量",
     monitoringNoCpuData: "等待 CPU 指标数据",
     monitoringNoMemoryData: "等待内存指标数据",
@@ -1392,6 +1415,10 @@ const messages = {
     navActivity: "Monitoring",
     navVersions: "Versions",
     navSettings: "Settings",
+    navOverviewGroup: "Overview",
+    navResourcesGroup: "Resources",
+    navOperationsGroup: "Operations",
+    navSystemGroup: "System",
     userProfile: "User profile",
     userAvatarAlt: "Pixel player avatar",
     localUser: "Local Player",
@@ -1526,10 +1553,26 @@ const messages = {
     english: "EN",
     dashboardTitle: "Dashboard",
     dashboardDescription: "Manage your game servers in one place.",
+    dashboardInfrastructureDescription: "Infrastructure and game server runtime overview.",
+    dashboardSummary: "Runtime summary",
+    dashboardAlerts: "Alerts",
+    dashboardResourceTrend: "Resource Trends",
+    dashboardResourceTrendDescription: "Historical host metrics refreshed every 30 seconds.",
+    dashboardResourceMetric: "Resource metric",
+    dashboardNetwork: "Network",
+    dashboardServerInstances: "Server Instances",
+    dashboardViewAll: "View all",
+    dashboardRecentEvents: "Recent Events",
+    dashboardSystemStatus: "System Status",
+    dashboardPanelService: "Panel Service",
+    dashboardMetricsService: "Monitoring Data",
+    dashboardStatusNormal: "Normal",
+    dashboardOpenMonitoring: "Open monitoring center",
     runningServers: "Running Servers",
     runningHint: "{count} running",
     onlinePlayers: "Online Players",
     playersOnlineHint: "All server capacity",
+    playerStatsUnavailableHint: "Player statistics are not provided by this game",
     latestBackup: "Latest Backup",
     storageUsed: "Storage Used",
     storageHint: "GamePanel data directory",
@@ -1543,6 +1586,8 @@ const messages = {
     createBackupQuickHint: "Open a server detail page",
     runtimeOverview: "Runtime Monitor",
     runtimeOverviewHint: "Current server resource usage",
+    serverStatusDistribution: "Server status distribution",
+    statusTransitioning: "In progress",
     chooseWorldFileToImport: "Choose a `.wld` world file to import.",
     createBackup: "Create Backup",
     serversTitle: "Servers",
@@ -1580,6 +1625,7 @@ const messages = {
     resourceLimits: "Resource Limits",
     resourceLimitsHint: "Set CPU and memory limits for the server container. Leave unlimited when no cap is needed.",
     runtimeResources: "Runtime Resources",
+    viewDetails: "View details",
     runtimeResourcesHint: "Container CPU / memory limits and current usage.",
     adjustResources: "Adjust Resources",
     advancedRuntimeResources: "Advanced: Runtime Resources",
@@ -2770,13 +2816,26 @@ function formatMessage(message: string, params?: Record<string, string | number>
 }
 
 export function localizeRelativeTime(value: string, locale: Locale) {
+  const normalizedTimestamp = value.replace(/\.(\d{3})\d*(Z|[+-]\d{2}:\d{2})$/, ".$1$2");
+  const timestamp = new Date(normalizedTimestamp).getTime();
+  if (Number.isFinite(timestamp) && /[T ]\d{2}:\d{2}/.test(value)) {
+    const deltaSeconds = Math.round((timestamp - Date.now()) / 1000);
+    const units: Array<[Intl.RelativeTimeFormatUnit, number]> = [
+      ["year", 31_536_000],
+      ["month", 2_592_000],
+      ["day", 86_400],
+      ["hour", 3_600],
+      ["minute", 60]
+    ];
+    const formatter = new Intl.RelativeTimeFormat(locale === "zh" ? "zh-CN" : "en-US", { numeric: "auto" });
+    for (const [unit, seconds] of units) {
+      if (Math.abs(deltaSeconds) >= seconds) return formatter.format(Math.round(deltaSeconds / seconds), unit);
+    }
+    return formatter.format(deltaSeconds, "second");
+  }
   if (locale === "en") return value;
   if (value === "Not yet" || value === "Unknown") return value === "Not yet" ? "暂无" : "未知";
-  return value
-    .replace("Just now", "刚刚")
-    .replace("min ago", "分钟前")
-    .replace("h ago", "小时前")
-    .replace("d ago", "天前");
+  return value.replace("Just now", "刚刚").replace("min ago", "分钟前").replace("h ago", "小时前").replace("d ago", "天前");
 }
 
 export function localizeWorldSize(value: string, locale: Locale) {

--- a/apps/web/lib/sparkline.tsx
+++ b/apps/web/lib/sparkline.tsx
@@ -13,10 +13,15 @@ export function useTimeSeries(value: number | undefined, maxPoints = MAX_POINTS)
 
   useEffect(() => {
     if (value === undefined) return;
-    const now = Date.now();
-    if (now - lastTsRef.current < 500) return;
-    lastTsRef.current = now;
-    setSeries((prev) => [...prev.slice(-(maxPoints - 1)), { value, ts: now }]);
+    const sample = () => {
+      const now = Date.now();
+      if (now - lastTsRef.current < 500) return;
+      lastTsRef.current = now;
+      setSeries((prev) => [...prev.slice(-(maxPoints - 1)), { value, ts: now }]);
+    };
+    sample();
+    const timer = window.setInterval(sample, 5000);
+    return () => window.clearInterval(timer);
   }, [value, maxPoints]);
 
   return series;
@@ -28,7 +33,8 @@ export function Sparkline({
   height = 36,
   color = "#7bd978",
   max = 100,
-  fill = true
+  fill = true,
+  className = ""
 }: {
   data: SeriesPoint[];
   width?: number;
@@ -36,10 +42,11 @@ export function Sparkline({
   color?: string;
   max?: number;
   fill?: boolean;
+  className?: string;
 }) {
   if (data.length < 2) {
     return (
-      <svg width={width} height={height} className="opacity-30">
+      <svg width={width} height={height} className={`opacity-30 ${className}`} preserveAspectRatio="none" viewBox={`0 0 ${width} ${height}`}>
         <line x1={0} y1={height / 2} x2={width} y2={height / 2} stroke={color} strokeWidth={1} strokeDasharray="3 3" />
       </svg>
     );
@@ -58,7 +65,7 @@ export function Sparkline({
   const gradId = `spark-${color.replace(/[^a-z0-9]/gi, "")}`;
 
   return (
-    <svg width={width} height={height} className="overflow-visible">
+    <svg width={width} height={height} className={`overflow-visible ${className}`} preserveAspectRatio="none" viewBox={`0 0 ${width} ${height}`}>
       {fill && (
         <>
           <defs>


### PR DESCRIPTION
## Summary
- redesign the dashboard around operational KPIs, historical resource trends, dense server inventory, recent events, and system health
- group navigation by overview, resources, operations, and system while moving create-server actions into page context
- replace low-density server cards with responsive resource tables and refine desktop action menus, artwork badges, player-data empty states, and preset density

## Validation
- pnpm --dir apps/web typecheck
- pnpm --dir apps/web lint
- pnpm --dir apps/web build
- git diff --check