### PR TITLE
fix: 优化服务器资源列与发布文档

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,98 +1,174 @@
-# GamePanel Lite
+<h1 align="center">GamePanel Lite</h1>
 
-GamePanel Lite is a lightweight, self-hosted game server panel for players, friend groups, and community server owners. It gives you a clean web interface for creating servers, starting and stopping instances, checking logs, managing worlds, backing up data, and discovering mods.
+<p align="center">
+  A lightweight, self-hosted control panel for running game servers with Docker.
+</p>
 
-[Live demo](https://dev.gamepanel.site) · [中文文档](docs/README.zh-CN.md)
+<p align="center">
+  <a href="https://dev.gamepanel.site">Live demo</a> ·
+  <a href="#quick-start">Quick start</a> ·
+  <a href="docs/README.zh-CN.md">简体中文</a> ·
+  <a href="https://github.com/smartcat999/game-panel-lite/releases">Releases</a>
+</p>
 
-![GamePanel Lite dashboard](docs/assets/dashboard.png)
+<p align="center">
+  <a href="https://github.com/smartcat999/game-panel-lite/releases"><img alt="Latest release" src="https://img.shields.io/github/v/release/smartcat999/game-panel-lite?display_name=tag&sort=semver"></a>
+  <a href="LICENSE"><img alt="License" src="https://img.shields.io/github/license/smartcat999/game-panel-lite"></a>
+  <img alt="Docker" src="https://img.shields.io/badge/runtime-Docker-2496ED?logo=docker&logoColor=white">
+  <img alt="Go API" src="https://img.shields.io/badge/API-Go-00ADD8?logo=go&logoColor=white">
+  <img alt="Next.js web" src="https://img.shields.io/badge/Web-Next.js-111111?logo=next.js&logoColor=white">
+</p>
 
-## Why GamePanel Lite
+![GamePanel Lite dashboard](apps/web/public/official/interface-dashboard.png)
 
-Running a game server should not mean juggling shell commands, scattered config files, and manual folders. GamePanel Lite brings the everyday server workflow into one focused dashboard.
+GamePanel Lite gives players and small server operators one place to create instances, inspect health, manage configuration and mods, view logs, and protect world data. Each game server runs in an isolated container with its own data directory. The panel stays self-hosted and does not require a cloud account or hosted control plane.
 
-- Self-hosted: run it on your own machine or VPS.
-- Player-friendly: built around servers, worlds, backups, logs, join info, and mods.
-- Lightweight: no cloud account, no billing system, no SaaS lock-in.
-- Multi-instance: keep each server isolated with its own data directory.
-- Extensible: starts with Terraria-focused workflows and expands toward more game providers.
+## Capabilities
 
-## What You Can Do
+| Area | What is included |
+| --- | --- |
+| Instances | Create, start, stop, restart, filter, and manage multiple isolated servers |
+| Configuration | Provider-aware fields, reusable presets, resource limits, and port allocation |
+| Operations | Live status, logs, console access, player information, and join details |
+| Data | World import, backup, restore, migration, and isolated instance directories |
+| Mods | Workshop discovery, mod library, mod packs, server assignment, and tModLoader ModConfig files |
+| Monitoring | Host and container metrics backed by Prometheus, cAdvisor, and node-exporter |
+| Updates | Runtime-image management, SteamCMD game-file updates, and asynchronous panel updates |
 
-- Create and manage multiple game servers
-- Start, stop, and restart server instances
-- View server status, logs, and console output
-- Import, back up, restore, and manage worlds
-- Discover recommended mods and add them to servers
-- Keep server files, worlds, backups, and mods organized in one place
+### Included game providers
+
+| Game | Runtime mode |
+| --- | --- |
+| Terraria | Vanilla, tModLoader |
+| Don't Starve Together | Master and optional Caves shards |
+| Palworld | Dedicated server |
+| Minecraft | Java Edition |
+
+Provider capabilities differ by game. The interface only exposes configuration, world, mod, and update operations supported by the selected provider.
 
 ## Quick Start
 
-Run this on a server with Docker installed:
+### Requirements
+
+- Linux host with Docker Engine and the Docker Compose plugin
+- `curl` and `tar`
+- An `amd64` host for the published control-plane images
+- Writable installation directory and enough disk space for game files, worlds, backups, and mods
+
+Install the current stable release:
 
 ```bash
-# Default: installs to ~/gamepanel-lite
+# Installs to ~/gamepanel-lite
 curl -fsSL https://raw.githubusercontent.com/smartcat999/game-panel-lite/main/scripts/install-online.sh | sh
 
-# Or specify a custom install path:
+# Or choose an installation directory
 curl -fsSL https://raw.githubusercontent.com/smartcat999/game-panel-lite/main/scripts/install-online.sh | sh -s -- "$HOME/apps/gamepanel-lite"
 ```
 
-The target directory must be writable by the current user. Use elevated permissions only when installing into a system directory such as `/opt`.
+Open `http://YOUR_SERVER_IP:3001` after the containers start.
 
-Then open:
+### Enable HTTPS
 
-```text
-http://YOUR_SERVER_IP:3001
-```
-
-If you have a domain pointed at the server, enable HTTPS:
-
-```bash
-cd ~/gamepanel-lite && sudo sh scripts/setup-https.sh your-domain.com your-email@example.com
-```
-
-On a systemd host, HTTPS setup installs a persistent daily certificate-renewal timer. Certbot only replaces a certificate after it enters the renewal window; the check itself is safe to run every day. Existing HTTPS installs can enable the timer with:
+Point a domain at the host, then run:
 
 ```bash
 cd ~/gamepanel-lite
-sudo sh scripts/install-https-renewal-timer.sh
-sudo systemctl status gamepanel-lite-https-renewal.timer
+sudo sh scripts/setup-https.sh panel.example.com admin@example.com
 ```
 
-Run a renewal check immediately or inspect its logs with:
+HTTPS uses `compose.prod.yaml` together with `compose.https.yaml`. The override replaces the same Nginx service, so one reverse proxy owns the public ports. On systemd hosts, setup also installs a daily certificate-renewal check.
+
+## Operations
+
+Run control-plane operations from the installation directory:
 
 ```bash
-sudo systemctl start gamepanel-lite-https-renewal.service
+sudo sh scripts/manage.sh status
+sudo sh scripts/manage.sh start
+sudo sh scripts/manage.sh update
+sudo sh scripts/manage.sh stop
+```
+
+`manage.sh update` pulls and recreates changed panel services. It does not recreate game containers or modify saves. The Settings page offers the same panel-update workflow when the updater service is available.
+
+Useful checks:
+
+```bash
+docker compose -f compose.prod.yaml ps
+curl http://127.0.0.1:3001/healthz
 sudo journalctl -u gamepanel-lite-https-renewal.service
 ```
 
-The Certbot Compose service is isolated behind the `certificate` profile, so ordinary control-plane starts no longer create a stopped Certbot container.
+### Update boundaries
 
-## Remote Server Operations
+GamePanel Lite separates three kinds of updates:
 
-Update the control-plane images and recreate only changed services:
+1. **Panel release:** API, Web, exporter, updater, and deployment files.
+2. **Runtime image:** the provider image used when an instance is created or its image is changed.
+3. **Game files:** files inside an existing server data directory, updated by SteamCMD where supported.
 
-```bash
-cd ~/gamepanel-lite
-sudo sh scripts/manage.sh update
+Updating the panel does not stop game servers. Updating a runtime image does not silently replace an existing server's game files. Server-level game-file updates remain available even when a newer runtime image has not been published yet.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    Browser["Browser"] --> Proxy["Nginx"]
+    Proxy --> Web["Next.js Web"]
+    Proxy --> API["Go API"]
+    API --> DB["SQLite + data directory"]
+    API --> Docker["Docker RuntimeAdapter"]
+    Docker --> Games["Isolated game containers"]
+    Exporter["GamePanel exporter"] --> Prometheus["Prometheus"]
+    Docker --> Exporter
+    Prometheus --> API
 ```
 
-Use `start`, `stop`, or `status` in place of `update` for routine operations. The script automatically selects HTTP or HTTPS mode. It manages the panel control plane only; game containers remain under GamePanel Lite and are not recreated by these commands.
+The API keeps provider-specific behavior outside the Docker runtime adapter. One server instance maps to one container and one isolated data directory.
 
-The Settings page can also check for a newer GamePanel Lite release and, when the updater service is enabled, install it asynchronously. Panel updates pull and recreate only the API, Web, and exporter control-plane services; running game containers and save data are left untouched. Automatic checks only notify and never install an update without confirmation.
+## Data and Backups
 
-Release images are built with the configured buildx builder (default `my-builder`) for `linux/amd64`:
+Persistent state is stored under `data/` in the installation directory:
+
+- SQLite database and panel settings
+- Per-instance game files and saves
+- Imported worlds and generated configuration
+- Backups, mods, and mod configuration
+- Prometheus time-series data
+
+Back up the entire `data/` directory before moving the installation or performing host-level maintenance. Do not expose arbitrary host paths to game containers.
+
+## Development
+
+The backend is Go with chi, SQLite, and the Docker SDK. The frontend is Next.js, React, TypeScript, Tailwind CSS, and TanStack Query.
+
+```bash
+pnpm install
+
+# Run the API and Web development servers
+pnpm dev:api
+pnpm dev:web
+
+# Required checks
+go test ./...
+go vet ./...
+pnpm lint
+pnpm typecheck
+pnpm build
+```
+
+Production panel images are built with the configured buildx builder (`my-builder` by default) for `linux/amd64`:
 
 ```bash
 scripts/build-panel-images.sh --version v0.2.0 --push
 ```
 
-Production uses `compose.prod.yaml`. The HTTPS override replaces the same `nginx` service, so only one reverse proxy owns ports 80 and 443. Do not add the development `compose.yaml` to production commands.
+## Project Status
 
-## Data Location
+GamePanel Lite is under active development and intended for early self-hosted use. Review the [release notes](https://github.com/smartcat999/game-panel-lite/releases) before updating, and keep an external copy of important worlds and backups.
 
-GamePanel Lite stores its data in the `data/` directory inside the install folder. This includes the local database, server instances, worlds, backups, and mod files.
+Bug reports and focused feature requests are welcome in [GitHub Issues](https://github.com/smartcat999/game-panel-lite/issues).
 
-## Current Status
+## License
 
-GamePanel Lite is in active development and ready for early self-hosted use. The current focus is Terraria / tModLoader server management, with ongoing work for Don't Starve Together and Palworld mod workflows.
+GamePanel Lite is released under the [MIT License](LICENSE).

--- a/apps/web/components/server-management-table.tsx
+++ b/apps/web/components/server-management-table.tsx
@@ -71,7 +71,7 @@ export function ServerManagementTable({
               <SortableHeader active={sort === "status"} direction={direction} label={t("status")} onClick={() => onSort("status")} />
               <th className="px-3 py-2.5">{t("gameAndMode")}</th>
               {visibleColumns.has("players") ? <th className="px-3 py-2.5">{t("players")}</th> : null}
-              {visibleColumns.has("resources") ? <th className="px-3 py-2.5">{t("resources")}</th> : null}
+              {visibleColumns.has("resources") ? <th className="w-44 px-3 py-2.5">{t("resources")}</th> : null}
               {visibleColumns.has("address") ? <th className="px-3 py-2.5">{t("serverAddress")}</th> : null}
               {visibleColumns.has("activity") ? <SortableHeader active={sort === "updatedAt"} direction={direction} label={t("recentActivity")} onClick={() => onSort("updatedAt")} /> : null}
               {visibleColumns.has("version") ? <th className="px-3 py-2.5">{t("version")}</th> : null}
@@ -109,8 +109,8 @@ export function ServerManagementTable({
                   </td>
                   {visibleColumns.has("players") ? <td className="px-3 py-2.5 font-mono text-slate-300">{typeof server.status.playersOnline === "number" ? `${server.status.playersOnline}/${gameServerMaxPlayers(server)}` : <DataMissing />}</td> : null}
                   {visibleColumns.has("resources") ? (
-                    <td className="px-3 py-2.5 font-mono text-xs">
-                      {metric?.statsAvailable ? <><span className="block text-slate-200">CPU {metric.cpuPercent.toFixed(1)}%</span><span className="mt-0.5 block text-slate-500">{formatMemory(metric.memoryMb)}</span></> : <DataMissing />}
+                    <td className="px-3 py-2.5">
+                      <ResourceUsage metric={metric} />
                     </td>
                   ) : null}
                   {visibleColumns.has("address") ? (
@@ -152,7 +152,7 @@ export function ServerManagementTable({
               </div>
               <div className="mt-3 grid grid-cols-2 gap-x-4 gap-y-2 border-y border-panel-line py-2.5 text-xs">
                 <MobileMetric icon={<Users className="size-3.5" />} label={t("players")} value={typeof server.status.playersOnline === "number" ? `${server.status.playersOnline}/${gameServerMaxPlayers(server)}` : "—"} />
-                <MobileMetric label={t("resources")} value={metric?.statsAvailable ? `${metric.cpuPercent.toFixed(1)}% · ${formatMemory(metric.memoryMb)}` : "—"} />
+                <MobileResourceUsage metric={metric} />
                 <MobileMetric icon={<Plug className="size-3.5" />} label={t("serverAddress")} value={address} />
                 <MobileMetric label={t("recentActivity")} value={formatRelativeTime(server.updatedAt, locale)} />
               </div>
@@ -176,8 +176,35 @@ function MobileMetric({ icon, label, value }: { icon?: React.ReactNode; label: s
   return <div className="min-w-0"><span className="flex items-center gap-1 text-slate-500">{icon}{label}</span><span className="mt-0.5 block truncate font-mono text-slate-200">{value}</span></div>;
 }
 
+function MobileResourceUsage({ metric }: { metric?: ObservabilityServerMetric }) {
+  const { t } = useI18n();
+  return (
+    <div className="min-w-0">
+      <span className="text-slate-500">{t("resources")}</span>
+      <div className="mt-0.5"><ResourceUsage metric={metric} /></div>
+    </div>
+  );
+}
+
+function ResourceUsage({ metric }: { metric?: ObservabilityServerMetric }) {
+  const { t } = useI18n();
+  if (!metric?.statsAvailable) return <DataMissing />;
+  return (
+    <div className="grid min-w-36 grid-cols-[2.5rem_auto] items-baseline gap-x-2 gap-y-0.5 text-xs">
+      <span className="text-slate-500">{t("cpu")}</span>
+      <span className="font-mono tabular-nums text-slate-200">{metric.cpuPercent.toFixed(1)}%</span>
+      <span className="text-slate-500">{t("memory")}</span>
+      <span className="whitespace-nowrap font-mono tabular-nums text-slate-200">{formatMemoryUsage(metric)}</span>
+    </div>
+  );
+}
+
 function DataMissing() { return <span className="text-slate-600">—</span>; }
 function formatMemory(value: number) { return value >= 1024 ? `${(value / 1024).toFixed(1)} GB` : `${Math.round(value)} MB`; }
+function formatMemoryUsage(metric: ObservabilityServerMetric) {
+  const usage = formatMemory(metric.memoryMb);
+  return metric.memoryLimitMb > 0 ? `${usage} / ${formatMemory(metric.memoryLimitMb)}` : usage;
+}
 function formatAddress(host: string | undefined, port: number) { const normalized = host?.trim(); if (!normalized) return `:${port}`; return normalized.includes(":") && !normalized.startsWith("[") ? `[${normalized}]:${port}` : `${normalized}:${port}`; }
 function formatTimestamp(value: string, locale: string) { const date = new Date(value); return Number.isNaN(date.getTime()) ? "—" : new Intl.DateTimeFormat(locale === "zh" ? "zh-CN" : "en-US", { dateStyle: "medium", timeStyle: "short" }).format(date); }
 function formatRelativeTime(value: string, locale: string) { const date = new Date(value); if (Number.isNaN(date.getTime())) return "—"; const seconds = Math.round((date.getTime() - Date.now()) / 1000); const abs = Math.abs(seconds); const formatter = new Intl.RelativeTimeFormat(locale === "zh" ? "zh-CN" : "en-US", { numeric: "auto" }); if (abs < 60) return formatter.format(seconds, "second"); if (abs < 3600) return formatter.format(Math.round(seconds / 60), "minute"); if (abs < 86400) return formatter.format(Math.round(seconds / 3600), "hour"); return formatter.format(Math.round(seconds / 86400), "day"); }

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,108 +1,174 @@
-# GamePanel Lite
+<h1 align="center">GamePanel Lite</h1>
 
-GamePanel Lite 是一个轻量、现代、可自托管的游戏服务器管理面板，适合个人玩家、朋友小队、社区服主和私服管理员使用。你可以通过网页创建服务器、启动和停止实例、查看日志、管理世界、备份数据，并发现和安装模组。
+<p align="center">
+  基于 Docker 的轻量级自托管游戏服务器管理面板。
+</p>
 
-[官网/体验地址](https://dev.gamepanel.site) · [English README](../README.md)
+<p align="center">
+  <a href="https://dev.gamepanel.site">在线体验</a> ·
+  <a href="#快速开始">快速开始</a> ·
+  <a href="../README.md">English</a> ·
+  <a href="https://github.com/smartcat999/game-panel-lite/releases">版本说明</a>
+</p>
 
-![GamePanel Lite 仪表盘](assets/dashboard.png)
+<p align="center">
+  <a href="https://github.com/smartcat999/game-panel-lite/releases"><img alt="最新版本" src="https://img.shields.io/github/v/release/smartcat999/game-panel-lite?display_name=tag&sort=semver"></a>
+  <a href="../LICENSE"><img alt="开源许可证" src="https://img.shields.io/github/license/smartcat999/game-panel-lite"></a>
+  <img alt="Docker" src="https://img.shields.io/badge/运行环境-Docker-2496ED?logo=docker&logoColor=white">
+  <img alt="Go API" src="https://img.shields.io/badge/API-Go-00ADD8?logo=go&logoColor=white">
+  <img alt="Next.js Web" src="https://img.shields.io/badge/Web-Next.js-111111?logo=next.js&logoColor=white">
+</p>
 
-## 为什么选择 GamePanel Lite
+![GamePanel Lite 仪表盘](../apps/web/public/official/interface-dashboard.png)
 
-开游戏服务器不应该依赖一堆命令、散落的配置文件和手动整理目录。GamePanel Lite 把常用的服务器管理流程整理到一个清晰的网页里，让开服和维护更简单。
+GamePanel Lite 为个人玩家、朋友小队和小型社区服主提供统一的服务器管理入口。每个游戏服务器使用独立容器和数据目录运行，可以在网页中创建实例、查看状态、管理配置与模组、读取日志并保护世界数据。面板完全自托管，不依赖云厂商账号或托管控制平面。
 
-- 自托管：部署在你自己的机器或服务器上。
-- 面向玩家：围绕服务器、世界、备份、日志、连接信息和模组设计。
-- 轻量运行：不绑定云厂商，不需要复杂账号体系。
-- 多实例管理：每个服务器都有独立的数据目录。
-- 持续扩展：从 Terraria 体验起步，逐步扩展更多游戏和模组生态。
+## 能力范围
 
-## 核心功能
+| 领域 | 已支持能力 |
+| --- | --- |
+| 实例 | 创建、启动、停止、重启、筛选和批量管理多个独立服务器 |
+| 配置 | 游戏专属参数、配置预设、资源限制和端口分配 |
+| 运维 | 实时状态、日志、控制台、玩家信息和加入方式 |
+| 数据 | 世界导入、备份、恢复、迁移和独立实例目录 |
+| 模组 | 创意工坊发现、模组库、模组包、服务器安装和 tModLoader ModConfig |
+| 监控 | 基于 Prometheus、cAdvisor 和 node-exporter 的主机与容器指标 |
+| 更新 | 运行镜像管理、SteamCMD 游戏文件更新和异步面板更新 |
 
-- 创建和管理多个游戏服务器
-- 启动、停止、重启服务器实例
-- 查看服务器状态、日志和控制台
-- 导入、备份、恢复和管理世界文件
-- 发现推荐模组并加入服务器
-- 集中管理服务器文件、世界、备份和模组
+### 已包含的游戏提供器
+
+| 游戏 | 运行模式 |
+| --- | --- |
+| Terraria | 原版、tModLoader |
+| 饥荒联机版 | 地面分片和可选洞穴分片 |
+| 幻兽帕鲁 | 专用服务器 |
+| 我的世界 | Java 版 |
+
+不同游戏提供器的能力范围并不完全相同。界面只会展示当前提供器支持的配置、世界、模组和更新操作。
 
 ## 快速开始
 
-准备一台已经安装 Docker 的服务器，然后运行：
+### 环境要求
+
+- 安装了 Docker Engine 和 Docker Compose 插件的 Linux 主机
+- `curl` 与 `tar`
+- 使用官方控制平面镜像时需要 `amd64` 主机
+- 可写的安装目录，以及足够保存游戏文件、世界、备份和模组的磁盘空间
+
+安装当前稳定版本：
 
 ```bash
 # 默认安装到 ~/gamepanel-lite
 curl -fsSL https://raw.githubusercontent.com/smartcat999/game-panel-lite/main/scripts/install-online.sh | sh
 
-# 或指定自定义安装路径：
+# 或指定安装目录
 curl -fsSL https://raw.githubusercontent.com/smartcat999/game-panel-lite/main/scripts/install-online.sh | sh -s -- "$HOME/apps/gamepanel-lite"
 ```
 
-目标目录必须允许当前用户写入。只有安装到 `/opt` 等系统目录时才需要使用提升后的权限。
+容器启动后访问 `http://服务器IP:3001`。
 
-启动完成后访问：
+### 启用 HTTPS
 
-```text
-http://服务器IP:3001
-```
-
-如果你已经把域名解析到服务器，可以开启 HTTPS：
-
-```bash
-cd ~/gamepanel-lite && sudo sh scripts/setup-https.sh your-domain.com your-email@example.com
-```
-
-在使用 systemd 的主机上，HTTPS 初始化会安装持久化的每日证书续期检查。Certbot 只有在证书进入续期窗口后才会真正替换证书，因此每天检查是安全的。已有 HTTPS 部署可以执行：
+先把域名解析到服务器，然后执行：
 
 ```bash
 cd ~/gamepanel-lite
-sudo sh scripts/install-https-renewal-timer.sh
-sudo systemctl status gamepanel-lite-https-renewal.timer
+sudo sh scripts/setup-https.sh panel.example.com admin@example.com
 ```
 
-立即执行一次续期检查或查看日志：
+HTTPS 部署会组合使用 `compose.prod.yaml` 和 `compose.https.yaml`。覆盖文件替换的是同一个 Nginx 服务，不会创建第二个反向代理。使用 systemd 的主机会同时安装每日证书续期检查。
+
+## 日常运维
+
+在安装目录中执行控制平面操作：
 
 ```bash
-sudo systemctl start gamepanel-lite-https-renewal.service
+sudo sh scripts/manage.sh status
+sudo sh scripts/manage.sh start
+sudo sh scripts/manage.sh update
+sudo sh scripts/manage.sh stop
+```
+
+`manage.sh update` 只拉取并重建发生变化的面板服务，不会重建游戏容器或修改存档。启用 updater 服务后，也可以在设置页完成同样的异步面板更新流程。
+
+常用检查命令：
+
+```bash
+docker compose -f compose.prod.yaml ps
+curl http://127.0.0.1:3001/healthz
 sudo journalctl -u gamepanel-lite-https-renewal.service
 ```
 
-Certbot Compose 服务已放入 `certificate` profile，普通控制平面启动不会再创建一个退出状态的 Certbot 容器。
+### 三种更新的边界
 
-## 远程服务器维护
+GamePanel Lite 明确区分三类更新：
 
-生产环境只使用 `compose.prod.yaml`。启用 HTTPS 后，`compose.https.yaml` 会替换同一个 `nginx` 服务的端口和配置，不会再创建第二个 Nginx。
+1. **面板版本：** API、Web、exporter、updater 和部署文件。
+2. **运行镜像：** 创建实例或主动切换镜像时使用的游戏提供器镜像。
+3. **游戏文件：** 已有服务器数据目录中的文件，在支持时通过 SteamCMD 更新。
 
-在远程服务器更新控制平面镜像并重建有变化的服务：
+更新面板不会停止游戏服务器；更新运行镜像不会静默替换已有服务器的游戏文件；即使新的运行镜像尚未发布，服务器仍然可以使用游戏文件更新功能。
 
-```bash
-cd ~/gamepanel-lite
-sudo sh scripts/manage.sh update
+## 系统结构
+
+```mermaid
+flowchart LR
+    Browser["浏览器"] --> Proxy["Nginx"]
+    Proxy --> Web["Next.js Web"]
+    Proxy --> API["Go API"]
+    API --> DB["SQLite 与数据目录"]
+    API --> Docker["Docker RuntimeAdapter"]
+    Docker --> Games["独立游戏容器"]
+    Exporter["GamePanel exporter"] --> Prometheus["Prometheus"]
+    Docker --> Exporter
+    Prometheus --> API
 ```
 
-启动、停止和查看状态：
+API 将游戏专属逻辑与 Docker 运行适配器分离。一个服务器实例对应一个容器和一个独立数据目录。
+
+## 数据与备份
+
+持久化数据默认保存在安装目录的 `data/` 下：
+
+- SQLite 数据库与面板设置
+- 各实例的游戏文件和存档
+- 导入的世界与生成的配置
+- 备份、模组和模组配置
+- Prometheus 时序数据
+
+迁移安装目录或进行主机级维护前，请备份完整的 `data/` 目录。不要向游戏容器暴露任意主机路径。
+
+## 本地开发
+
+后端使用 Go、chi、SQLite 和 Docker SDK；前端使用 Next.js、React、TypeScript、Tailwind CSS 和 TanStack Query。
 
 ```bash
-sudo sh scripts/manage.sh start
-sudo sh scripts/manage.sh stop
-sudo sh scripts/manage.sh status
+pnpm install
+
+# 分别启动 API 和 Web 开发服务
+pnpm dev:api
+pnpm dev:web
+
+# 必需检查
+go test ./...
+go vet ./...
+pnpm lint
+pnpm typecheck
+pnpm build
 ```
 
-`manage.sh` 会自动检测当前是 HTTP 还是 HTTPS 部署。它只管理面板、API、Nginx 和监控服务；帕鲁、饥荒等游戏容器仍由 GamePanel Lite 管理，不会在更新控制平面时被重建。
-
-设置页也支持检查 GamePanel Lite 新版本。启用独立 updater 服务后，管理员确认即可异步安装；更新只拉取并重建 API、Web 和 exporter 控制平面服务，不会停止游戏容器或修改存档。自动检查只提醒，不会自动安装。
-
-发布面板镜像时统一使用 buildx builder（默认 `my-builder`）构建 `linux/amd64` 镜像：
+发布面板镜像时使用配置好的 buildx builder（默认为 `my-builder`），并构建 `linux/amd64` 镜像：
 
 ```bash
 scripts/build-panel-images.sh --version v0.2.0 --push
 ```
 
-不要在生产服务器叠加使用 `compose.yaml`。该文件用于本地开发，可能额外暴露 Web 端口。
+## 项目状态
 
-## 数据保存
+GamePanel Lite 正在持续开发，适合早期自托管使用。更新前请阅读[版本说明](https://github.com/smartcat999/game-panel-lite/releases)，并为重要世界和备份保留一份外部副本。
 
-GamePanel Lite 默认把数据保存在安装目录下的 `data/`，包括本地数据库、服务器实例、世界、备份和模组文件。
+欢迎通过 [GitHub Issues](https://github.com/smartcat999/game-panel-lite/issues) 提交可复现的问题和范围明确的功能建议。
 
-## 当前状态
+## 开源许可证
 
-GamePanel Lite 正在积极开发中，适合早期自托管试用。当前重点完善 Terraria / tModLoader 服务器管理，同时继续推进 Don't Starve Together 和 Palworld 的模组管理流程。
+GamePanel Lite 使用 [MIT License](../LICENSE)。

--- a/release/manifest.json
+++ b/release/manifest.json
@@ -3,7 +3,7 @@
   "channel": "stable",
   "version": "v0.2.0",
   "publishedAt": "2026-08-17T00:00:00Z",
-  "releaseNotesUrl": "https://github.com/smartcat999/game-panel-lite/releases",
+  "releaseNotesUrl": "https://github.com/smartcat999/game-panel-lite/releases/tag/v0.2.0",
   "images": {
     "api": {
       "dockerHub": "docker.io/smartcat99999/game-panel-lite-api:v0.2.0",

--- a/release/notes/v0.2.0.md
+++ b/release/notes/v0.2.0.md
@@ -1,0 +1,66 @@
+# GamePanel Lite v0.2.0
+
+GamePanel Lite v0.2.0 is the first versioned control-plane release. It consolidates the server-management workflows developed during the V1 cycle and introduces an asynchronous self-update path for future releases.
+
+## Highlights
+
+- Added a dense operations dashboard with host and container resource trends.
+- Added searchable, filterable server tables with batch actions and safer destructive operations.
+- Added runtime providers for Terraria Vanilla, tModLoader, Don't Starve Together, Palworld, and Minecraft Java Edition.
+- Added provider-aware configuration, reusable presets, CPU and memory limits, and automatic port allocation.
+- Added world import, backup, restore, migration, and regeneration workflows where supported.
+- Added Workshop discovery, a shared mod library, mod packs, server mod assignment, and tModLoader ModConfig management.
+- Added separate runtime-image and SteamCMD game-file update workflows.
+- Added panel release checks and asynchronous control-plane updates that do not recreate running game containers.
+- Added Prometheus, cAdvisor, node-exporter, and GamePanel exporter integration.
+- Added one-command HTTPS setup with persistent certificate-renewal checks.
+
+## Operations
+
+- Production deployments use `compose.prod.yaml`.
+- HTTPS deployments combine `compose.prod.yaml` with `compose.https.yaml`; both files describe the same Nginx service.
+- Panel updates recreate control-plane services only. Game containers and their data directories remain untouched.
+- Published control-plane images target `linux/amd64` and are available from Docker Hub and the Aliyun Hangzhou registry.
+
+## Upgrade
+
+From the installation directory, run:
+
+```bash
+sudo sh scripts/manage.sh update
+```
+
+You can also open **Settings → Panel updates**, check for v0.2.0, and confirm installation when the updater service is available.
+
+Back up the installation's `data/` directory before host-level maintenance or migration.
+
+---
+
+## 中文说明
+
+GamePanel Lite v0.2.0 是首个正式编号的控制平面版本，汇总了 V1 阶段的服务器管理能力，并为后续版本加入异步面板更新流程。
+
+### 主要变化
+
+- 新增高密度运维仪表盘，以及主机和容器资源趋势。
+- 新增支持搜索、筛选、批量操作和安全删除的服务器列表。
+- 包含 Terraria 原版、tModLoader、饥荒联机版、幻兽帕鲁和我的世界 Java 版提供器。
+- 新增游戏专属配置、可复用预设、CPU/内存限制和自动端口分配。
+- 按提供器支持世界导入、备份、恢复、迁移和重新生成。
+- 新增创意工坊发现、共享模组库、模组包、服务器模组分配和 tModLoader ModConfig 管理。
+- 区分运行镜像更新与 SteamCMD 游戏文件更新。
+- 新增面板版本检查和异步更新，不会重建运行中的游戏容器。
+- 集成 Prometheus、cAdvisor、node-exporter 和 GamePanel exporter。
+- 新增一键 HTTPS 配置和持久化证书续期检查。
+
+### 更新方法
+
+在安装目录执行：
+
+```bash
+sudo sh scripts/manage.sh update
+```
+
+也可以进入 **设置 → 面板更新**，检查 v0.2.0 并在 updater 服务可用时确认安装。
+
+进行主机维护或迁移前，请备份安装目录中的 `data/`。


### PR DESCRIPTION
## 变更\n- 服务器资源列明确区分 CPU 与内存，并在存在限制时显示内存用量/上限\n- 桌面端和移动端统一支持中英文资源标签\n- 重构中英文 README 的安装、运维、架构与数据说明\n- 增加 v0.2.0 中英文版本说明并链接到固定 Release\n\n## 验证\n- pnpm --dir apps/web lint\n- pnpm --dir apps/web typecheck\n- pnpm --dir apps/web build\n- go test ./apps/api/internal/systemupdate\n- GitHub Markdown rendering API\n- git diff --check