### PR TITLE
docs: 修正 Apache 2.0 许可证标识

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,4 +171,4 @@ Bug reports and focused feature requests are welcome in [GitHub Issues](https://
 
 ## License
 
-GamePanel Lite is released under the [MIT License](LICENSE).
+GamePanel Lite is released under the [Apache License 2.0](LICENSE).

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -405,7 +405,7 @@ export default function HomePage() {
         <div className="mx-auto flex max-w-6xl flex-col gap-6 px-4 py-8 text-sm text-[#bccabb] sm:px-6 md:flex-row md:items-center md:justify-between lg:px-8">
           <div>
             <p className="font-semibold text-white">GamePanel Lite</p>
-            <p className="mt-1 text-xs">Released under MIT License.</p>
+            <p className="mt-1 text-xs">Released under Apache License 2.0.</p>
           </div>
           <nav className="flex flex-wrap gap-4">
             <Link href="/dashboard" className="hover:text-[#6bfb9a]">Dashboard</Link>

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -171,4 +171,4 @@ GamePanel Lite 正在持续开发，适合早期自托管使用。更新前请�
 
 ## 开源许可证
 
-GamePanel Lite 使用 [MIT License](../LICENSE)。
+GamePanel Lite 使用 [Apache License 2.0](../LICENSE)。


### PR DESCRIPTION
## 变更\n- 将英文 README 的许可证从 MIT 修正为 Apache License 2.0\n- 同步修正中文 README 与产品首页页脚\n- 保留第三方依赖各自的许可证声明\n\n## 验证\n- pnpm --dir apps/web lint\n- pnpm --dir apps/web typecheck\n- pnpm --dir apps/web build\n- git diff --check