### PR TITLE
fix: 手动续期后保留 systemd 调度方式

### DIFF
--- a/apps/updater/cmd/server/main.go
+++ b/apps/updater/cmd/server/main.go
@@ -269,12 +269,21 @@ func (u *updater) runRenewalScheduler(ctx context.Context) {
 }
 
 func (u *updater) runHTTPSRenewal() error {
+	method := u.renewalMethod()
 	if err := u.execCommand("sh", filepath.Join(u.workspace, "scripts", "renew-https.sh")); err != nil {
-		u.writeAutoRenewalStatus("updater", "failed", true)
+		u.writeAutoRenewalStatus(method, "failed", true)
 		return err
 	}
-	u.writeAutoRenewalStatus("updater", "success", true)
+	u.writeAutoRenewalStatus(method, "success", true)
 	return nil
+}
+
+func (u *updater) renewalMethod() string {
+	status := u.readAutoRenewalStatus()
+	if status.Enabled && status.Method == "systemd" {
+		return "systemd"
+	}
+	return "updater"
 }
 
 func (u *updater) writeAutoRenewalStatus(method, status string, enabled bool) {

--- a/apps/updater/cmd/server/main_test.go
+++ b/apps/updater/cmd/server/main_test.go
@@ -85,4 +85,7 @@ func TestReadAutoRenewalStatus(t *testing.T) {
 	if !status.Enabled || status.Method != "systemd" || status.LastStatus != "success" {
 		t.Fatalf("unexpected auto renewal status: %#v", status)
 	}
+	if got := u.renewalMethod(); got != "systemd" {
+		t.Fatalf("renewalMethod = %q", got)
+	}
 }


### PR DESCRIPTION
## 变更\n- 手动证书续期不再把已有 systemd 自动续签状态改写为 Updater\n- Updater 仅在没有 systemd timer 时接管每日调度\n- 增加续签方式保留测试\n\n## 验证\n- go test ./apps/updater/cmd/server\n- go vet ./apps/updater/cmd/server\n- git diff --check