### PR TITLE
fix: 使用 Release 资产检查面板更新

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,7 @@ GAMEPANEL_CADVISOR_TAG="v0.52.1"
 GAMEPANEL_NODE_EXPORTER_TAG="v1.10.2"
 GAMEPANEL_UPDATER_TOKEN="replace-with-a-random-64-character-token"
 GAMEPANEL_SYSTEM_UPDATE_INTERVAL="24h"
+GAMEPANEL_RELEASE_MANIFEST_URL="https://github.com/smartcat999/game-panel-lite/releases/latest/download/manifest.json"
 
 # China mirror example:
 # GAMEPANEL_IMAGE_REGION="cn"

--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ The mirror job is pinned to `linux/amd64` and publishes Nginx, Certbot, Promethe
 
 GamePanel Lite is under active development and intended for early self-hosted use. Review the [release notes](https://github.com/smartcat999/game-panel-lite/releases) before updating, and keep an external copy of important worlds and backups.
 
+The update checker downloads `manifest.json` from the latest GitHub Release asset rather than Raw GitHub, avoiding source-file scraping limits. Each release must publish the matching manifest asset before it is announced as stable.
+
 Bug reports and focused feature requests are welcome in [GitHub Issues](https://github.com/smartcat999/game-panel-lite/issues).
 
 ## License

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -55,7 +55,7 @@ func Load() Config {
 		ImageTag:               value("GAMEPANEL_IMAGE_TAG", "v0.2.4"),
 		PrometheusURL:          value("GAMEPANEL_PROMETHEUS_URL", ""),
 		PrometheusQueryTimeout: queryTimeout,
-		ReleaseManifestURL:     value("GAMEPANEL_RELEASE_MANIFEST_URL", "https://raw.githubusercontent.com/smartcat999/game-panel-lite/main/release/manifest.json"),
+		ReleaseManifestURL:     value("GAMEPANEL_RELEASE_MANIFEST_URL", "https://github.com/smartcat999/game-panel-lite/releases/latest/download/manifest.json"),
 		SystemUpdateInterval:   updateInterval,
 		UpdaterURL:             value("GAMEPANEL_UPDATER_URL", ""),
 		UpdaterToken:           value("GAMEPANEL_UPDATER_TOKEN", ""),

--- a/apps/api/internal/http/system_handlers_test.go
+++ b/apps/api/internal/http/system_handlers_test.go
@@ -3,14 +3,50 @@ package http
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"log/slog"
 	stdhttp "net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/smartcat999/game-panel-lite/apps/api/internal/domain"
+	"github.com/smartcat999/game-panel-lite/apps/api/internal/systemupdate"
 )
+
+func TestAutomaticSystemUpdateCheckDoesNotRunAtStartup(t *testing.T) {
+	var requests atomic.Int32
+	manifest := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, _ *stdhttp.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"schemaVersion":1,"channel":"stable","version":"v9.9.9"}`))
+	}))
+	defer manifest.Close()
+
+	_, db, cfg := newTestRouter(t)
+	cfg.SystemUpdateInterval = time.Hour
+	handler := &Handler{
+		cfg:          cfg,
+		logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		store:        db,
+		systemUpdate: systemupdate.New(manifest.URL, "", "", time.Second),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		handler.runAutomaticSystemUpdateChecks(ctx)
+		close(done)
+	}()
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	<-done
+
+	if got := requests.Load(); got != 0 {
+		t.Fatalf("automatic update check sent %d request(s) during startup", got)
+	}
+}
 
 func TestMonitoringRoutesAreRegistered(t *testing.T) {
 	router, _, _ := newTestRouter(t)

--- a/apps/api/internal/http/system_update_handlers.go
+++ b/apps/api/internal/http/system_update_handlers.go
@@ -149,7 +149,6 @@ func (h *Handler) runAutomaticSystemUpdateChecks(ctx context.Context) {
 			h.recordActivity(context.Background(), "", "system.update.available", fmt.Sprintf("GamePanel Lite %s is available", status.Latest.Version), map[string]any{"version": status.Latest.Version})
 		}
 	}
-	check()
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -15,7 +15,7 @@ services:
       GAMEPANEL_IMAGE_TAG: ${GAMEPANEL_IMAGE_TAG:-v0.2.4}
       GAMEPANEL_PROMETHEUS_URL: http://prometheus:9090
       GAMEPANEL_PROMETHEUS_QUERY_TIMEOUT: 2s
-      GAMEPANEL_RELEASE_MANIFEST_URL: ${GAMEPANEL_RELEASE_MANIFEST_URL:-https://raw.githubusercontent.com/smartcat999/game-panel-lite/main/release/manifest.json}
+      GAMEPANEL_RELEASE_MANIFEST_URL: ${GAMEPANEL_RELEASE_MANIFEST_URL:-https://github.com/smartcat999/game-panel-lite/releases/latest/download/manifest.json}
       GAMEPANEL_SYSTEM_UPDATE_INTERVAL: ${GAMEPANEL_SYSTEM_UPDATE_INTERVAL:-24h}
       GAMEPANEL_UPDATER_URL: http://updater:4020
       GAMEPANEL_UPDATER_TOKEN: ${GAMEPANEL_UPDATER_TOKEN:?GAMEPANEL_UPDATER_TOKEN is required}

--- a/compose.yaml
+++ b/compose.yaml
@@ -21,7 +21,7 @@ services:
       GAMEPANEL_IMAGE_TAG: ${GAMEPANEL_IMAGE_TAG:-v0.2.4}
       GAMEPANEL_PROMETHEUS_URL: http://prometheus:9090
       GAMEPANEL_PROMETHEUS_QUERY_TIMEOUT: 2s
-      GAMEPANEL_RELEASE_MANIFEST_URL: ${GAMEPANEL_RELEASE_MANIFEST_URL:-https://raw.githubusercontent.com/smartcat999/game-panel-lite/main/release/manifest.json}
+      GAMEPANEL_RELEASE_MANIFEST_URL: ${GAMEPANEL_RELEASE_MANIFEST_URL:-https://github.com/smartcat999/game-panel-lite/releases/latest/download/manifest.json}
       GAMEPANEL_SYSTEM_UPDATE_INTERVAL: ${GAMEPANEL_SYSTEM_UPDATE_INTERVAL:-24h}
       GAMEPANEL_UPDATER_URL: http://updater:4020
       GAMEPANEL_UPDATER_TOKEN: ${GAMEPANEL_UPDATER_TOKEN:-local-development-token}

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -176,6 +176,8 @@ scripts/mirror-control-plane-images.sh --push
 
 GamePanel Lite 正在持续开发，适合早期自托管使用。更新前请阅读[版本说明](https://github.com/smartcat999/game-panel-lite/releases)，并为重要世界和备份保留一份外部副本。
 
+版本检查会从最新 GitHub Release 资产下载 `manifest.json`，不再访问容易触发源码抓取限流的 Raw GitHub。发布稳定版本前必须先上传与版本匹配的 Manifest 资产。
+
 欢迎通过 [GitHub Issues](https://github.com/smartcat999/game-panel-lite/issues) 提交可复现的问题和范围明确的功能建议。
 
 ## 开源许可证


### PR DESCRIPTION
## 问题

- 生产服务器访问 Raw GitHub 的 release/manifest.json 时返回 HTTP 429
- API 每次启动都会立即执行一次自动版本检查，升级或恢复期间会产生非周期请求

## 修复

- 默认 Manifest 地址切换为 releases/latest/download/manifest.json
- 自动检查只在配置周期到期时触发
- API 启动、重启和恢复仅启动定时器，不再访问远端
- 用户点击检查更新仍会立即检查
- 设置页状态轮询仍只读取本地状态
- v0.2.4 Release 已上传 manifest.json 资产
- 生产环境已通过 .env 热修复并验证返回 200

## 验证

- 定向回归测试确认启动期间远端请求数为 0
- go test ./apps/api/internal/config ./apps/api/internal/systemupdate
- go vet ./...
- git diff --check

完整 HTTP 包中的既有 Palworld 更新测试会因本机剩余磁盘不足 8 GiB 失败，与本次改动无关。