### PR TITLE
docs: 简化安装与 HTTPS 配置流程

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,46 +58,74 @@ Provider capabilities differ by game. The interface only exposes configuration, 
 Install the current stable release:
 
 ```bash
-# Installs to ~/gamepanel-lite
+# Interactive installation; choose the directory and image region when prompted.
 curl -fsSL https://raw.githubusercontent.com/smartcat999/game-panel-lite/main/scripts/install-online.sh | sh
 
-# Or choose an installation directory
+# Non-interactive China Mainland installation
+curl -fsSL https://raw.githubusercontent.com/smartcat999/game-panel-lite/main/scripts/install-online.sh | GAMEPANEL_IMAGE_REGION=cn sh
+
+# Optional custom installation directory
 curl -fsSL https://raw.githubusercontent.com/smartcat999/game-panel-lite/main/scripts/install-online.sh | sh -s -- "$HOME/apps/gamepanel-lite"
 ```
 
-Open `http://YOUR_SERVER_IP:3001` after the containers start.
+The installer defaults to the last successful installation directory, or `~/gamepanel-lite` on first use. The control-plane registry is selected during installation and remains independent from the game-image region configured later in the panel. Re-running the installer detects the existing directory and region, while still allowing either value to be changed.
+
+After the containers start:
+
+1. Open `http://YOUR_SERVER_IP:3001`.
+2. Create the local administrator account.
+3. Install a runtime image from **Game Library**.
+4. Select **Create server** and follow the guided setup.
 
 ### Enable HTTPS
 
-Point a domain at the host, then run:
+HTTPS is configured from the panel:
+
+1. Point the panel domain to the server and allow TCP ports `80` and `443`.
+2. Open **Settings → Access & HTTPS**.
+3. Enter the domain and an optional certificate email.
+4. Select **Configure HTTPS** and confirm the short control-plane restart.
+
+GamePanel Lite configures Nginx, requests the certificate, switches the panel entry point, and enables renewal checks. Running game servers are not restarted.
+
+<details>
+<summary>Command-line fallback</summary>
+
+Use this only when the panel is unavailable or the current deployment driver cannot manage HTTPS:
 
 ```bash
 cd ~/gamepanel-lite
 sudo sh scripts/setup-https.sh panel.example.com admin@example.com
 ```
 
-HTTPS uses `compose.prod.yaml` together with `compose.https.yaml`. The override replaces the same Nginx service, so one reverse proxy owns the public ports. On systemd hosts, setup also installs a daily certificate-renewal check.
+</details>
 
 ## Operations
 
-Run control-plane operations from the installation directory:
+Routine control-plane work is available in the panel:
+
+- **Settings → Updates & Maintenance:** service status, recovery, restart, and panel updates.
+- **Settings → Access & HTTPS:** certificate status, HTTPS setup, and renewal checks.
+- **Monitoring:** host, container, and game-server health.
+
+Control-plane maintenance does not recreate managed game containers or modify save data.
+
+<details>
+<summary>Command-line recovery and diagnostics</summary>
 
 ```bash
+cd ~/gamepanel-lite
 sudo sh scripts/manage.sh status
 sudo sh scripts/manage.sh start
 sudo sh scripts/manage.sh update
 sudo sh scripts/manage.sh stop
-```
 
-`manage.sh update` pulls and recreates changed panel services. It does not recreate game containers or modify saves. The Settings page offers the same panel-update workflow when the updater service is available.
-
-Useful checks:
-
-```bash
 docker compose -f compose.prod.yaml ps
 curl http://127.0.0.1:3001/healthz
 sudo journalctl -u gamepanel-lite-https-renewal.service
 ```
+
+</details>
 
 ### Update boundaries
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -58,46 +58,74 @@ GamePanel Lite 为个人玩家、朋友小队和小型社区服主提供统一�
 安装当前稳定版本：
 
 ```bash
-# 默认安装到 ~/gamepanel-lite
+# 交互式安装；根据提示选择安装目录和镜像区域。
 curl -fsSL https://raw.githubusercontent.com/smartcat999/game-panel-lite/main/scripts/install-online.sh | sh
 
-# 或指定安装目录
+# 中国大陆非交互式安装
+curl -fsSL https://raw.githubusercontent.com/smartcat999/game-panel-lite/main/scripts/install-online.sh | GAMEPANEL_IMAGE_REGION=cn sh
+
+# 可选：指定安装目录
 curl -fsSL https://raw.githubusercontent.com/smartcat999/game-panel-lite/main/scripts/install-online.sh | sh -s -- "$HOME/apps/gamepanel-lite"
 ```
 
-容器启动后访问 `http://服务器IP:3001`。
+首次安装默认使用 `~/gamepanel-lite`，之后会默认显示上次成功安装的目录。控制平面仓库在安装时选择，后续与面板中的游戏镜像区域保持独立。重复运行安装器时会识别已有目录和区域，也允许重新选择；切换区域前会自动备份 `.env`。
+
+容器启动后：
+
+1. 访问 `http://服务器IP:3001`。
+2. 创建本地管理员账号。
+3. 在**游戏库**安装运行镜像。
+4. 点击**创建服务器**并按向导完成配置。
 
 ### 启用 HTTPS
 
-先把域名解析到服务器，然后执行：
+HTTPS 直接在面板中配置：
+
+1. 将面板域名解析到服务器，并开放 TCP `80`、`443` 端口。
+2. 打开**设置 → 访问与 HTTPS**。
+3. 填写域名和可选的证书邮箱。
+4. 点击**配置 HTTPS**，确认控制平面的短暂重启。
+
+GamePanel Lite 会自动配置 Nginx、申请证书、切换面板入口并启用续签检查，不会重启正在运行的游戏服务器。
+
+<details>
+<summary>命令行备用方式</summary>
+
+仅在面板无法访问，或当前部署驱动不支持管理 HTTPS 时使用：
 
 ```bash
 cd ~/gamepanel-lite
 sudo sh scripts/setup-https.sh panel.example.com admin@example.com
 ```
 
-HTTPS 部署会组合使用 `compose.prod.yaml` 和 `compose.https.yaml`。覆盖文件替换的是同一个 Nginx 服务，不会创建第二个反向代理。使用 systemd 的主机会同时安装每日证书续期检查。
+</details>
 
 ## 日常运维
 
-在安装目录中执行控制平面操作：
+常用控制平面操作已经集成到面板：
+
+- **设置 → 更新与维护：** 服务状态、恢复、重启和面板更新。
+- **设置 → 访问与 HTTPS：** 证书状态、HTTPS 配置和续签检查。
+- **监控：** 宿主机、容器和游戏服务器健康状态。
+
+控制平面维护不会重建游戏容器，也不会修改存档。
+
+<details>
+<summary>命令行恢复与诊断</summary>
 
 ```bash
+cd ~/gamepanel-lite
 sudo sh scripts/manage.sh status
 sudo sh scripts/manage.sh start
 sudo sh scripts/manage.sh update
 sudo sh scripts/manage.sh stop
-```
 
-`manage.sh update` 只拉取并重建发生变化的面板服务，不会重建游戏容器或修改存档。启用 updater 服务后，也可以在设置页完成同样的异步面板更新流程。
-
-常用检查命令：
-
-```bash
 docker compose -f compose.prod.yaml ps
 curl http://127.0.0.1:3001/healthz
 sudo journalctl -u gamepanel-lite-https-renewal.service
 ```
+
+</details>
 
 ### 三种更新的边界
 

--- a/scripts/install-online.sh
+++ b/scripts/install-online.sh
@@ -2,10 +2,43 @@
 set -eu
 
 REPO_ARCHIVE_URL="${GAMEPANEL_ARCHIVE_URL:-https://github.com/smartcat999/game-panel-lite/archive/refs/heads/main.tar.gz}"
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/gamepanel-lite"
+INSTALL_PATH_FILE="$CONFIG_DIR/install-path"
+
 if [ -n "${1:-}" ]; then
   INSTALL_DIR="$1"
+elif [ -n "${GAMEPANEL_INSTALL_DIR:-}" ]; then
+  INSTALL_DIR="$GAMEPANEL_INSTALL_DIR"
 else
-  INSTALL_DIR="${GAMEPANEL_INSTALL_DIR:-$HOME/gamepanel-lite}"
+  DEFAULT_INSTALL_DIR="$HOME/gamepanel-lite"
+  if [ -r "$INSTALL_PATH_FILE" ]; then
+    saved_install_dir=$(sed -n '1p' "$INSTALL_PATH_FILE")
+    [ -n "$saved_install_dir" ] && DEFAULT_INSTALL_DIR="$saved_install_dir"
+  fi
+  if [ -r /dev/tty ] && [ -w /dev/tty ]; then
+    printf "Install directory / 安装目录 [%s]: " "$DEFAULT_INSTALL_DIR" >/dev/tty
+    IFS= read -r selected_install_dir </dev/tty || selected_install_dir=""
+    INSTALL_DIR="${selected_install_dir:-$DEFAULT_INSTALL_DIR}"
+  else
+    INSTALL_DIR="$DEFAULT_INSTALL_DIR"
+    echo "No interactive terminal detected; using installation directory: $INSTALL_DIR"
+  fi
+fi
+
+case "$INSTALL_DIR" in
+  "~") INSTALL_DIR="$HOME" ;;
+  "~/"*) INSTALL_DIR="$HOME/${INSTALL_DIR#\~/}" ;;
+  /*) ;;
+  *) INSTALL_DIR="$(pwd)/$INSTALL_DIR" ;;
+esac
+
+if [ "$INSTALL_DIR" = "/" ]; then
+  echo "Refusing to install into the filesystem root" >&2
+  exit 2
+fi
+
+if [ -f "$INSTALL_DIR/.env" ]; then
+  echo "Existing installation detected / 检测到已有安装: $INSTALL_DIR"
 fi
 
 if ! command -v curl >/dev/null 2>&1; then
@@ -35,6 +68,10 @@ cp -R "$TMP_DIR/source/." "$INSTALL_DIR/"
 chmod +x "$INSTALL_DIR/scripts/install.sh" "$INSTALL_DIR/scripts/setup-https.sh" "$INSTALL_DIR/scripts/renew-https.sh" "$INSTALL_DIR/scripts/install-https-renewal-timer.sh" "$INSTALL_DIR/scripts/https-renewal-runner.sh" "$INSTALL_DIR/scripts/manage.sh" 2>/dev/null || true
 
 sh "$INSTALL_DIR/scripts/install.sh"
+
+mkdir -p "$CONFIG_DIR"
+printf '%s\n' "$INSTALL_DIR" > "$INSTALL_PATH_FILE"
+chmod 600 "$INSTALL_PATH_FILE"
 
 echo
 echo "Install directory: $INSTALL_DIR"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,6 +4,103 @@ set -eu
 ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 ENV_FILE="$ROOT_DIR/.env"
 
+read_env_value() {
+  key="$1"
+  [ -f "$ENV_FILE" ] || return 0
+  if [ -r "$ENV_FILE" ]; then
+    line=$(sed -n "s/^${key}=//p" "$ENV_FILE" | tail -n 1)
+  elif command -v sudo >/dev/null 2>&1; then
+    line=$(sudo sed -n "s/^${key}=//p" "$ENV_FILE" | tail -n 1)
+  else
+    return 0
+  fi
+  printf '%s' "$line" | sed 's/^"//; s/"$//'
+}
+
+update_existing_region() {
+  source_file=$(mktemp)
+  output_file=$(mktemp)
+  if [ -r "$ENV_FILE" ]; then
+    cp "$ENV_FILE" "$source_file"
+  elif command -v sudo >/dev/null 2>&1; then
+    sudo cp "$ENV_FILE" "$source_file"
+    sudo chown "$(id -u):$(id -g)" "$source_file"
+  else
+    echo "Cannot read existing $ENV_FILE" >&2
+    return 1
+  fi
+  awk -v region="$IMAGE_REGION" -v registry="$IMAGE_REGISTRY" '
+    BEGIN { saw_region=0; saw_registry=0 }
+    /^GAMEPANEL_IMAGE_REGION=/ { print "GAMEPANEL_IMAGE_REGION=\"" region "\""; saw_region=1; next }
+    /^GAMEPANEL_IMAGE_REGISTRY=/ { print "GAMEPANEL_IMAGE_REGISTRY=\"" registry "\""; saw_registry=1; next }
+    { print }
+    END {
+      if (!saw_region) print "GAMEPANEL_IMAGE_REGION=\"" region "\""
+      if (!saw_registry) print "GAMEPANEL_IMAGE_REGISTRY=\"" registry "\""
+    }
+  ' "$source_file" > "$output_file"
+  if [ -w "$ENV_FILE" ]; then
+    cp "$output_file" "$ENV_FILE"
+  elif command -v sudo >/dev/null 2>&1; then
+    sudo cp "$output_file" "$ENV_FILE"
+  else
+    echo "Cannot update existing $ENV_FILE" >&2
+    return 1
+  fi
+  rm -f "$source_file" "$output_file"
+}
+
+CURRENT_IMAGE_REGION=$(read_env_value GAMEPANEL_IMAGE_REGION)
+CURRENT_IMAGE_REGISTRY=$(read_env_value GAMEPANEL_IMAGE_REGISTRY)
+case "$CURRENT_IMAGE_REGION" in
+  global|cn) ;;
+  *)
+    case "$CURRENT_IMAGE_REGISTRY" in
+      registry.cn-hangzhou.aliyuncs.com/gamepanel-lite) CURRENT_IMAGE_REGION="cn" ;;
+      *) CURRENT_IMAGE_REGION="global" ;;
+    esac
+    ;;
+esac
+
+IMAGE_REGION="${GAMEPANEL_IMAGE_REGION:-}"
+if [ -z "$IMAGE_REGION" ]; then
+  if [ -r /dev/tty ] && [ -w /dev/tty ]; then
+    default_selection="1"
+    [ "$CURRENT_IMAGE_REGION" = "cn" ] && default_selection="2"
+    while :; do
+      cat >/dev/tty <<EOF
+
+Select the control-plane image region / 选择控制平面镜像区域：
+  1) Global, Docker Hub / 全球，Docker Hub
+  2) China Mainland, Alibaba Cloud / 中国大陆，阿里云
+EOF
+      if [ -f "$ENV_FILE" ]; then
+        printf "Current / 当前: %s\n" "$CURRENT_IMAGE_REGION" >/dev/tty
+      fi
+      printf "Selection / 请选择 [%s]: " "$default_selection" >/dev/tty
+      IFS= read -r choice </dev/tty || choice=""
+      case "$choice" in
+        "") IMAGE_REGION="$CURRENT_IMAGE_REGION"; break ;;
+        1) IMAGE_REGION="global"; break ;;
+        2) IMAGE_REGION="cn"; break ;;
+        *) echo "Enter 1 or 2 / 请输入 1 或 2。" >/dev/tty ;;
+      esac
+    done
+  else
+    IMAGE_REGION="$CURRENT_IMAGE_REGION"
+    echo "No interactive terminal detected; keeping image region: $IMAGE_REGION"
+  fi
+fi
+case "$IMAGE_REGION" in
+  global) DEFAULT_IMAGE_REGISTRY="smartcat99999" ;;
+  cn) DEFAULT_IMAGE_REGISTRY="registry.cn-hangzhou.aliyuncs.com/gamepanel-lite" ;;
+  *) echo "GAMEPANEL_IMAGE_REGION must be global or cn" >&2; exit 2 ;;
+esac
+IMAGE_REGISTRY="${GAMEPANEL_IMAGE_REGISTRY:-$DEFAULT_IMAGE_REGISTRY}"
+
+echo "Control-plane image region: $IMAGE_REGION"
+echo "Control-plane image registry: $IMAGE_REGISTRY"
+
 if ! command -v docker >/dev/null 2>&1; then
   echo "Docker is required. Install Docker first, then run this script again."
   exit 1
@@ -22,12 +119,26 @@ GAMEPANEL_DOCKER_SOCKET_PATH="/var/run/docker.sock"
 GAMEPANEL_WEB_PORT="3001"
 GAMEPANEL_API_PORT="4000"
 NEXT_PUBLIC_API_BASE_URL=""
-GAMEPANEL_IMAGE_REGION="global"
-GAMEPANEL_IMAGE_REGISTRY="smartcat99999"
+GAMEPANEL_IMAGE_REGION="$IMAGE_REGION"
+GAMEPANEL_IMAGE_REGISTRY="$IMAGE_REGISTRY"
 GAMEPANEL_IMAGE_TAG="v0.2.4"
 GAMEPANEL_PALWORLD_MOD_PACK_TAG="v0.1.0"
 GAMEPANEL_UPDATER_TOKEN="$UPDATER_TOKEN"
 EOF
+elif [ "$CURRENT_IMAGE_REGION" != "$IMAGE_REGION" ] || [ "$CURRENT_IMAGE_REGISTRY" != "$IMAGE_REGISTRY" ]; then
+  backup_file="$ENV_FILE.bak-region-$(date +%Y%m%d-%H%M%S)"
+  if [ -r "$ENV_FILE" ] && [ -w "$(dirname "$ENV_FILE")" ]; then
+    cp "$ENV_FILE" "$backup_file"
+  elif command -v sudo >/dev/null 2>&1; then
+    sudo cp "$ENV_FILE" "$backup_file"
+  else
+    echo "Cannot back up existing $ENV_FILE" >&2
+    exit 1
+  fi
+  update_existing_region
+  echo "Updated existing image region. Backup: $backup_file"
+else
+  echo "Existing image region is unchanged."
 fi
 
 mkdir -p "$ROOT_DIR/data"

--- a/scripts/setup-https.sh
+++ b/scripts/setup-https.sh
@@ -5,6 +5,13 @@ ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 ENV_FILE="$ROOT_DIR/.env"
 DOMAIN="${1:-}"
 EMAIL="${2:-}"
+IMAGE_REGION="${GAMEPANEL_IMAGE_REGION:-global}"
+case "$IMAGE_REGION" in
+  global) DEFAULT_IMAGE_REGISTRY="smartcat99999" ;;
+  cn) DEFAULT_IMAGE_REGISTRY="registry.cn-hangzhou.aliyuncs.com/gamepanel-lite" ;;
+  *) echo "GAMEPANEL_IMAGE_REGION must be global or cn" >&2; exit 2 ;;
+esac
+IMAGE_REGISTRY="${GAMEPANEL_IMAGE_REGISTRY:-$DEFAULT_IMAGE_REGISTRY}"
 
 if [ -z "$DOMAIN" ]; then
   echo "Usage: sh scripts/setup-https.sh <domain> [email]"
@@ -31,8 +38,8 @@ GAMEPANEL_DOCKER_SOCKET_PATH="/var/run/docker.sock"
 GAMEPANEL_WEB_PORT="80"
 GAMEPANEL_HTTPS_PORT="443"
 NEXT_PUBLIC_API_BASE_URL=""
-GAMEPANEL_IMAGE_REGION="global"
-GAMEPANEL_IMAGE_REGISTRY="smartcat99999"
+GAMEPANEL_IMAGE_REGION="$IMAGE_REGION"
+GAMEPANEL_IMAGE_REGISTRY="$IMAGE_REGISTRY"
 GAMEPANEL_IMAGE_TAG="v0.2.4"
 GAMEPANEL_PALWORLD_MOD_PACK_TAG="v0.1.0"
 GAMEPANEL_DOMAIN="$DOMAIN"


### PR DESCRIPTION
## 变更内容

- 安装器交互式选择安装目录和控制平面镜像区域
- 记录上次成功安装目录，重复安装时自动识别并默认复用
- 重复安装可重新选择镜像区域，切换前自动备份 .env
- 非交互安装保留显式目录和区域环境变量
- 拒绝将文件系统根目录作为安装目录
- README 将 HTTPS 和日常维护调整为面板优先流程
- setup-https.sh 在独立运行时同样支持安装期区域变量
- 中英文文档保持一致

## 验证

- 首次自定义目录离线安装
- 重复安装自动复用目录并识别已有 .env
- 非交互重复安装保留原区域
- 显式区域覆盖与 .env 备份
- 根目录安装保护
- Shell 语法检查
- git diff --check