### PR TITLE
fix: 稳定面板版本检查

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,7 @@ GAMEPANEL_CADVISOR_TAG="v0.52.1"
 GAMEPANEL_NODE_EXPORTER_TAG="v1.10.2"
 GAMEPANEL_UPDATER_TOKEN="replace-with-a-random-64-character-token"
 GAMEPANEL_SYSTEM_UPDATE_INTERVAL="24h"
+GAMEPANEL_RELEASE_MANIFEST_URL="https://github.com/smartcat999/game-panel-lite/releases/latest/download/manifest.json"
 
 # China mirror example:
 # GAMEPANEL_IMAGE_REGION="cn"

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -55,7 +55,7 @@ func Load() Config {
 		ImageTag:               value("GAMEPANEL_IMAGE_TAG", "v0.2.4"),
 		PrometheusURL:          value("GAMEPANEL_PROMETHEUS_URL", ""),
 		PrometheusQueryTimeout: queryTimeout,
-		ReleaseManifestURL:     value("GAMEPANEL_RELEASE_MANIFEST_URL", "https://raw.githubusercontent.com/smartcat999/game-panel-lite/main/release/manifest.json"),
+		ReleaseManifestURL:     value("GAMEPANEL_RELEASE_MANIFEST_URL", "https://github.com/smartcat999/game-panel-lite/releases/latest/download/manifest.json"),
 		SystemUpdateInterval:   updateInterval,
 		UpdaterURL:             value("GAMEPANEL_UPDATER_URL", ""),
 		UpdaterToken:           value("GAMEPANEL_UPDATER_TOKEN", ""),

--- a/apps/api/internal/http/system_handlers_test.go
+++ b/apps/api/internal/http/system_handlers_test.go
@@ -3,14 +3,50 @@ package http
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"log/slog"
 	stdhttp "net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/smartcat999/game-panel-lite/apps/api/internal/domain"
+	"github.com/smartcat999/game-panel-lite/apps/api/internal/systemupdate"
 )
+
+func TestAutomaticSystemUpdateCheckDoesNotRunAtStartup(t *testing.T) {
+	var requests atomic.Int32
+	manifest := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, _ *stdhttp.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"schemaVersion":1,"channel":"stable","version":"v9.9.9"}`))
+	}))
+	defer manifest.Close()
+
+	_, db, cfg := newTestRouter(t)
+	cfg.SystemUpdateInterval = time.Hour
+	handler := &Handler{
+		cfg:          cfg,
+		logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		store:        db,
+		systemUpdate: systemupdate.New(manifest.URL, "", "", time.Second),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		handler.runAutomaticSystemUpdateChecks(ctx)
+		close(done)
+	}()
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	<-done
+
+	if got := requests.Load(); got != 0 {
+		t.Fatalf("automatic update check sent %d request(s) during startup", got)
+	}
+}
 
 func TestMonitoringRoutesAreRegistered(t *testing.T) {
 	router, _, _ := newTestRouter(t)

--- a/apps/api/internal/http/system_update_handlers.go
+++ b/apps/api/internal/http/system_update_handlers.go
@@ -149,7 +149,6 @@ func (h *Handler) runAutomaticSystemUpdateChecks(ctx context.Context) {
 			h.recordActivity(context.Background(), "", "system.update.available", fmt.Sprintf("GamePanel Lite %s is available", status.Latest.Version), map[string]any{"version": status.Latest.Version})
 		}
 	}
-	check()
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -15,7 +15,7 @@ services:
       GAMEPANEL_IMAGE_TAG: ${GAMEPANEL_IMAGE_TAG:-v0.2.4}
       GAMEPANEL_PROMETHEUS_URL: http://prometheus:9090
       GAMEPANEL_PROMETHEUS_QUERY_TIMEOUT: 2s
-      GAMEPANEL_RELEASE_MANIFEST_URL: ${GAMEPANEL_RELEASE_MANIFEST_URL:-https://raw.githubusercontent.com/smartcat999/game-panel-lite/main/release/manifest.json}
+      GAMEPANEL_RELEASE_MANIFEST_URL: ${GAMEPANEL_RELEASE_MANIFEST_URL:-https://github.com/smartcat999/game-panel-lite/releases/latest/download/manifest.json}
       GAMEPANEL_SYSTEM_UPDATE_INTERVAL: ${GAMEPANEL_SYSTEM_UPDATE_INTERVAL:-24h}
       GAMEPANEL_UPDATER_URL: http://updater:4020
       GAMEPANEL_UPDATER_TOKEN: ${GAMEPANEL_UPDATER_TOKEN:?GAMEPANEL_UPDATER_TOKEN is required}

--- a/compose.yaml
+++ b/compose.yaml
@@ -21,7 +21,7 @@ services:
       GAMEPANEL_IMAGE_TAG: ${GAMEPANEL_IMAGE_TAG:-v0.2.4}
       GAMEPANEL_PROMETHEUS_URL: http://prometheus:9090
       GAMEPANEL_PROMETHEUS_QUERY_TIMEOUT: 2s
-      GAMEPANEL_RELEASE_MANIFEST_URL: ${GAMEPANEL_RELEASE_MANIFEST_URL:-https://raw.githubusercontent.com/smartcat999/game-panel-lite/main/release/manifest.json}
+      GAMEPANEL_RELEASE_MANIFEST_URL: ${GAMEPANEL_RELEASE_MANIFEST_URL:-https://github.com/smartcat999/game-panel-lite/releases/latest/download/manifest.json}
       GAMEPANEL_SYSTEM_UPDATE_INTERVAL: ${GAMEPANEL_SYSTEM_UPDATE_INTERVAL:-24h}
       GAMEPANEL_UPDATER_URL: http://updater:4020
       GAMEPANEL_UPDATER_TOKEN: ${GAMEPANEL_UPDATER_TOKEN:-local-development-token}


### PR DESCRIPTION
## 修复内容

- 从 GitHub Release Asset 获取 `manifest.json`，避免 Raw GitHub 频率限制导致 HTTP 429
- 自动检查不再随 API 启动立即触发，只在配置周期到期时运行
- 保留设置页中的手动“检查更新”操作
- 增加回归测试，确保启动阶段不会请求版本清单

替代已产生冲突的 #99。

## 验证

- `go test ./apps/api/internal/http -run TestAutomaticSystemUpdateCheckDoesNotRunAtStartup -count=1 -v`
- `go test ./apps/api/internal/config ./apps/api/internal/systemupdate`
- `git diff --check`

完整 `http` 包仍有一个与本次无关的既有用例因本机可用磁盘不足 8 GiB 失败：`TestApplyGameUpdateBacksUpSaveAndCompletesAsynchronously`。