### PR TITLE
docs: 精简 README 并增加图文使用指南

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 <p align="center">
   <a href="https://dev.gamepanel.site">Live demo</a> ·
   <a href="#install">Install</a> ·
+  <a href="docs/USER_GUIDE.md">User guide</a> ·
   <a href="docs/README.zh-CN.md">简体中文</a> ·
   <a href="https://github.com/smartcat999/game-panel-lite/releases">Releases</a>
 </p>
@@ -21,76 +22,25 @@
   <sub>Dashboard · Guided setup · Mods · Presets · Monitoring · HTTPS</sub>
 </p>
 
-> GamePanel Lite is under active development. Keep an external copy of important saves and backups.
+Create and operate isolated game servers, manage settings and mods, inspect logs, and monitor resources from one panel.
 
-## What you can do
-
-- Create, start, stop, restart, inspect logs, and use the console for isolated servers.
-- Configure game settings, resources, ports, worlds, and backups.
-- Discover Workshop mods, build mod packs, and manage tModLoader ModConfig files.
-- Monitor resources and update the panel or supported game files from the UI.
-
-| Game | Modes |
-| --- | --- |
-| Terraria | Vanilla, tModLoader |
-| Don't Starve Together | Master, optional Caves shard |
-| Palworld | Dedicated server |
-| Minecraft | Java Edition |
+Supported: Terraria (Vanilla/tModLoader), Don't Starve Together, Palworld, and Minecraft Java Edition.
 
 ## Install
 
-Requirements: Linux `amd64`, Docker Engine, and the Docker Compose plugin. The installer downloads the latest stable Tag, not the development branch.
+Requires Linux `amd64`, Docker Engine, and Docker Compose.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/smartcat999/game-panel-lite/main/scripts/install-online.sh | sh
 ```
 
-The installer asks for:
+## Get started
 
-1. Installation directory, defaulting to the last successful location or `~/gamepanel-lite`.
-2. Control-plane image region: Docker Hub or Alibaba Cloud.
-
-For unattended China Mainland installation:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/smartcat999/game-panel-lite/main/scripts/install-online.sh \
-  | GAMEPANEL_IMAGE_REGION=cn sh
-```
-
-## Use
-
-1. Open `http://YOUR_SERVER_IP:3001` and create the local administrator.
-2. Install a runtime image from **Game Library**.
-3. Select **Create server** and follow the guided setup.
-4. Open the game port shown on the server details page in the cloud and host firewalls.
-5. For HTTPS, point a domain to the server, allow TCP ports `80` and `443`, then open **Settings → Access & HTTPS**.
-6. Use **Settings → Updates & Maintenance** for panel updates and recovery.
-
-<table>
-  <tr>
-    <td align="center"><strong>Guided server creation</strong><br><img alt="Server creation wizard" src="apps/web/public/official/interface-servers.png"></td>
-    <td align="center"><strong>Workshop mods and mod packs</strong><br><img alt="Workshop discovery and mod library" src="apps/web/public/official/interface-mods.png"></td>
-  </tr>
-</table>
-
-<details>
-<summary>Command-line recovery</summary>
-
-```bash
-cd <installation-directory>
-sudo sh scripts/manage.sh status
-sudo sh scripts/manage.sh update
-sudo sh scripts/manage.sh start
-sudo sh scripts/manage.sh stop
-```
-
-</details>
+Open `http://YOUR_SERVER_IP:3001`, then follow the [illustrated user guide](docs/USER_GUIDE.md) or [简体中文图文指南](docs/USER_GUIDE.zh-CN.md).
 
 ## Feedback
 
-- [Report a bug](https://github.com/smartcat999/game-panel-lite/issues/new?template=bug_report.yml)
-- [Request a feature](https://github.com/smartcat999/game-panel-lite/issues/new?template=feature_request.yml)
-- Check [existing issues](https://github.com/smartcat999/game-panel-lite/issues) before submitting a duplicate.
+[Report a bug](https://github.com/smartcat999/game-panel-lite/issues/new?template=bug_report.yml) · [Request a feature](https://github.com/smartcat999/game-panel-lite/issues/new?template=feature_request.yml) · [Existing issues](https://github.com/smartcat999/game-panel-lite/issues)
 
 ## License
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -5,6 +5,7 @@
 <p align="center">
   <a href="https://dev.gamepanel.site">在线体验</a> ·
   <a href="#安装">安装</a> ·
+  <a href="USER_GUIDE.zh-CN.md">图文指南</a> ·
   <a href="../README.md">English</a> ·
   <a href="https://github.com/smartcat999/game-panel-lite/releases">版本说明</a>
 </p>
@@ -21,76 +22,25 @@
   <sub>仪表盘 · 创建向导 · 模组 · 预设 · 监控 · HTTPS</sub>
 </p>
 
-> GamePanel Lite 正在持续开发，请为重要存档和备份保留外部副本。
+在一个面板中创建和管理相互隔离的游戏服务器，调整配置与模组，并查看日志和资源监控。
 
-## 可以做什么
-
-- 创建、启动、停止、重启相互隔离的服务器，并查看日志和控制台。
-- 管理游戏参数、资源、端口、世界和备份。
-- 发现创意工坊模组、创建模组包并管理 tModLoader ModConfig。
-- 在界面中查看资源监控并更新面板或支持的游戏文件。
-
-| 游戏 | 模式 |
-| --- | --- |
-| Terraria | 原版、tModLoader |
-| 饥荒联机版 | 地面、可选洞穴分片 |
-| 幻兽帕鲁 | 专用服务器 |
-| 我的世界 | Java 版 |
+支持 Terraria（原版/tModLoader）、饥荒联机版、幻兽帕鲁和我的世界 Java 版。
 
 ## 安装
 
-环境要求：Linux `amd64`、Docker Engine 和 Docker Compose 插件。安装器会下载最新稳定 Tag，不会安装开发分支。
+需要 Linux `amd64`、Docker Engine 和 Docker Compose。
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/smartcat999/game-panel-lite/main/scripts/install-online.sh | sh
 ```
 
-安装器会依次询问：
+## 开始使用
 
-1. 安装目录，默认使用上次成功位置，首次安装为 `~/gamepanel-lite`。
-2. 控制平面镜像区域：Docker Hub 或阿里云。
-
-中国大陆无人值守安装：
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/smartcat999/game-panel-lite/main/scripts/install-online.sh \
-  | GAMEPANEL_IMAGE_REGION=cn sh
-```
-
-## 使用
-
-1. 打开 `http://服务器IP:3001`，创建本地管理员。
-2. 在**游戏库**安装运行镜像。
-3. 点击**创建服务器**，按向导完成配置。
-4. 根据服务器详情页显示的协议和端口，配置云防火墙与系统防火墙。
-5. 配置 HTTPS 时，先把域名解析到服务器并开放 TCP `80`、`443`，然后进入**设置 → 访问与 HTTPS**。
-6. 在**设置 → 更新与维护**完成面板更新和恢复操作。
-
-<table>
-  <tr>
-    <td align="center"><strong>引导式创建服务器</strong><br><img alt="创建服务器向导" src="../apps/web/public/official/interface-servers.png"></td>
-    <td align="center"><strong>创意工坊与模组包</strong><br><img alt="创意工坊发现与模组库" src="../apps/web/public/official/interface-mods.png"></td>
-  </tr>
-</table>
-
-<details>
-<summary>命令行恢复</summary>
-
-```bash
-cd <安装目录>
-sudo sh scripts/manage.sh status
-sudo sh scripts/manage.sh update
-sudo sh scripts/manage.sh start
-sudo sh scripts/manage.sh stop
-```
-
-</details>
+打开 `http://服务器IP:3001`，然后阅读[完整图文使用指南](USER_GUIDE.zh-CN.md)或 [English guide](USER_GUIDE.md)。
 
 ## 问题反馈
 
-- [提交缺陷](https://github.com/smartcat999/game-panel-lite/issues/new?template=bug_report.yml)
-- [建议功能](https://github.com/smartcat999/game-panel-lite/issues/new?template=feature_request.yml)
-- 提交前请先检查[已有 Issue](https://github.com/smartcat999/game-panel-lite/issues)，避免重复。
+[提交缺陷](https://github.com/smartcat999/game-panel-lite/issues/new?template=bug_report.yml) · [建议功能](https://github.com/smartcat999/game-panel-lite/issues/new?template=feature_request.yml) · [已有 Issue](https://github.com/smartcat999/game-panel-lite/issues)
 
 ## 开源许可证
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,0 +1,115 @@
+# GamePanel Lite Illustrated User Guide
+
+[Back to README](../README.md) · [简体中文](USER_GUIDE.zh-CN.md)
+
+This guide covers the path from first login to routine maintenance. Screens may evolve between releases, while the navigation and operating model remain consistent.
+
+## Installation
+
+Requirements: Linux `amd64`, Docker Engine, and Docker Compose. Run:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/smartcat999/game-panel-lite/main/scripts/install-online.sh | sh
+```
+
+The installer asks for the installation directory and image region. It defaults to the last successful directory, or `~/gamepanel-lite` on first use. For unattended mainland China installation:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/smartcat999/game-panel-lite/main/scripts/install-online.sh \
+  | GAMEPANEL_IMAGE_REGION=cn sh
+```
+
+## 1. Open the panel
+
+After installation, visit:
+
+```text
+http://YOUR_SERVER_IP:3001
+```
+
+Create the local administrator on first access. If the page is unreachable, allow TCP `3001` in both the cloud and host firewalls. Use the configured domain after enabling HTTPS.
+
+![Dashboard](../apps/web/public/official/interface-dashboard.png)
+
+The dashboard summarizes instance state and host resource trends.
+
+## 2. Install a runtime image
+
+Open **Game Library**, find the required game or mode, and select **Install runtime image**. The matching server can be created after its status becomes **Installed**.
+
+![Game Library](../apps/web/public/official/interface-worlds.png)
+
+The runtime image supplies the server environment. Each server keeps its save data, configuration, and game files in an isolated data directory.
+
+## 3. Create a server
+
+Select **Create server** in the page header and complete the wizard:
+
+1. Choose the game and runtime mode.
+2. Enter the server, world, password, and game settings.
+3. Set CPU, memory, and the external port.
+4. Select mods or a mod pack when supported.
+5. Review the summary and create the server.
+
+![Server creation wizard](../apps/web/public/official/interface-servers.png)
+
+Prefer automatic port allocation. When limiting memory, reserve capacity for the operating system, Docker, and the control panel.
+
+## 4. Allow the port and join
+
+The server detail page shows the final public address, port, and password. Check all of the following:
+
+- The cloud security group or firewall.
+- UFW, iptables, or another host firewall.
+- The TCP or UDP protocol required by the game.
+
+Use the actual port and protocol shown by the server rather than assuming the game's default. Update firewall rules whenever the external port changes.
+
+## 5. Manage servers
+
+The **Servers** page supports start, stop, restart, and bulk actions. Open a server to access its overview, join information, live logs, console, players, configuration, resources, and game-specific tabs.
+
+A running server must be stopped before deletion. Configuration and mod changes show whether a restart or world regeneration is required.
+
+## 6. Install and manage mods
+
+Open **Mods** to discover supported Workshop content, import mods, create reusable mod packs, and install them on a server.
+
+![Mod resource center](../apps/web/public/official/interface-mods.png)
+
+Client and server mod requirements differ. Check the mod classification and make sure players install the matching client version when required.
+
+## 7. HTTPS and panel updates
+
+### HTTPS
+
+1. Point a domain to the server's public IP.
+2. Allow TCP `80` and `443`.
+3. Open **Settings → Access & HTTPS**.
+4. Enter the domain and email, then enable HTTPS.
+
+The installed renewal timer manages certificate renewal. Its status and manual check are available on the same page.
+
+### Update the panel
+
+Open **Settings → Updates & Maintenance** to check and apply a release. Updating briefly restarts the control plane without recreating running game servers or save data.
+
+## 8. Recover from the command line
+
+If the panel is unavailable, connect over SSH and run these commands from the installation directory:
+
+```bash
+cd <installation-directory>
+sudo sh scripts/manage.sh status
+sudo sh scripts/manage.sh update
+sudo sh scripts/manage.sh start
+sudo sh scripts/manage.sh stop
+```
+
+Check control-plane status, container logs, free disk space, memory, listening ports, and firewall rules in that order. Include reproduction steps, screenshots, and sanitized logs in bug reports.
+
+## 9. Get help
+
+- [Report a bug](https://github.com/smartcat999/game-panel-lite/issues/new?template=bug_report.yml)
+- [Request a feature](https://github.com/smartcat999/game-panel-lite/issues/new?template=feature_request.yml)
+- [Review existing issues](https://github.com/smartcat999/game-panel-lite/issues)

--- a/docs/USER_GUIDE.zh-CN.md
+++ b/docs/USER_GUIDE.zh-CN.md
@@ -1,0 +1,121 @@
+# GamePanel Lite 图文使用指南
+
+[返回中文 README](README.zh-CN.md) · [English](USER_GUIDE.md)
+
+本指南覆盖从首次进入面板到日常维护的完整流程。界面可能随版本调整，但入口名称和操作逻辑保持一致。
+
+## 安装
+
+需要 Linux `amd64`、Docker Engine 和 Docker Compose。执行：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/smartcat999/game-panel-lite/main/scripts/install-online.sh | sh
+```
+
+安装器会询问安装目录和镜像区域。默认使用上次成功安装的位置，首次安装为 `~/gamepanel-lite`。中国大陆无人值守安装：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/smartcat999/game-panel-lite/main/scripts/install-online.sh \
+  | GAMEPANEL_IMAGE_REGION=cn sh
+```
+
+## 1. 进入面板
+
+安装完成后访问：
+
+```text
+http://服务器IP:3001
+```
+
+首次进入时创建本地管理员。若页面无法打开，请先确认云防火墙和系统防火墙已允许 TCP `3001`；配置 HTTPS 后应使用域名访问。
+
+![仪表盘](../apps/web/public/official/interface-dashboard.png)
+
+仪表盘用于快速确认实例数量、运行状态和宿主机资源趋势。
+
+## 2. 安装游戏运行镜像
+
+进入**游戏库**，找到需要运行的游戏或模式，点击**安装运行镜像**。状态变为**已安装**后才能创建对应服务器。
+
+![游戏库](../apps/web/public/official/interface-worlds.png)
+
+运行镜像只提供创建服务器所需的环境。服务器自己的存档、配置和游戏文件保存在独立数据目录中。
+
+## 3. 创建服务器
+
+点击页面右上角的**创建服务器**，按向导完成：
+
+1. 选择游戏与运行模式。
+2. 填写服务器名称、世界、密码和游戏参数。
+3. 设置 CPU、内存和外部端口。
+4. 选择模组或模组包（支持时）。
+5. 检查摘要并创建服务器。
+
+![创建服务器向导](../apps/web/public/official/interface-servers.png)
+
+建议优先使用自动分配端口；限制内存时应为操作系统、Docker 和面板保留空间。创建完成后可在服务器详情页启动实例。
+
+## 4. 开放端口并加入游戏
+
+服务器详情页会显示最终的公网地址、端口和密码。请同时检查：
+
+- 云厂商安全组或云防火墙。
+- Ubuntu 的 UFW、iptables 或其他系统防火墙。
+- 游戏要求的 TCP 或 UDP 协议。
+
+不要只根据游戏默认端口配置规则；应以当前服务器详情页显示的实际端口和协议为准。修改端口后也需要同步修改防火墙规则。
+
+## 5. 管理服务器
+
+在**服务器**列表中可以启动、停止、重启和批量管理实例。点击服务器名称进入详情页后，可以查看：
+
+- 概览与加入信息。
+- 实时日志和控制台。
+- 玩家状态。
+- 游戏配置与资源限制。
+- 模组和版本（按游戏能力显示）。
+
+运行中的服务器需要先停止才能删除。修改配置或模组后，界面会提示是否需要重启或重新生成世界。
+
+## 6. 安装和管理模组
+
+进入**模组**浏览支持的创意工坊内容，也可以导入模组、创建模组包，再安装到服务器。
+
+![模组资源中心](../apps/web/public/official/interface-mods.png)
+
+客户端模组与服务端模组的要求不同。加入服务器前，请根据模组分类确认玩家客户端是否也需要安装同一版本。
+
+## 7. HTTPS 与面板更新
+
+### HTTPS
+
+1. 将域名解析到服务器公网 IP。
+2. 放行 TCP `80` 和 `443`。
+3. 打开**设置 → 访问与 HTTPS**。
+4. 填写域名和邮箱并启用 HTTPS。
+
+证书续签由面板安装的定时任务管理，可在同一页面查看状态并手动检查。
+
+### 更新面板
+
+打开**设置 → 更新与维护**，手动检查新版本并执行更新。更新会短暂重启控制平面，但不会重建正在运行的游戏服务器或存档。
+
+## 8. 故障恢复
+
+面板不可用时，可 SSH 登录服务器并在安装目录执行：
+
+```bash
+cd <安装目录>
+sudo sh scripts/manage.sh status
+sudo sh scripts/manage.sh update
+sudo sh scripts/manage.sh start
+sudo sh scripts/manage.sh stop
+```
+
+排查顺序建议为：控制平面状态、容器日志、磁盘空间、内存、端口监听和防火墙规则。提交问题时请附上可复现步骤、页面截图和已脱敏的相关日志。
+
+## 9. 获取帮助
+
+- [提交缺陷](https://github.com/smartcat999/game-panel-lite/issues/new?template=bug_report.yml)
+- [建议功能](https://github.com/smartcat999/game-panel-lite/issues/new?template=feature_request.yml)
+- [查看已有问题](https://github.com/smartcat999/game-panel-lite/issues)


### PR DESCRIPTION
## 变更内容

- 将中英文 README 精简为项目介绍、演示、支持范围、安装命令、指南入口与问题反馈
- 将详细安装和使用步骤拆分为独立中英文图文指南
- 使用仓库内现有界面图片，不依赖外部图片地址
- 移除尚未开放的世界与备份功能说明
- 图文指南覆盖安装、创建服务器、端口、防火墙、模组、HTTPS、更新和故障恢复

## 验证

- `git diff --check`
- 仓库内引用图片存在性检查
- 中英文 README 均缩减至 47 行