### PR TITLE
fix: preserve worker data writability

### DIFF
--- a/apps/agent/reconcile.go
+++ b/apps/agent/reconcile.go
@@ -247,6 +247,9 @@ func createAgentContainer(client *http.Client, assignment workloadAssignment, lo
 			return err
 		}
 	}
+	if err := normalizeAgentInstancePermissions(instanceDir); err != nil {
+		return err
+	}
 	pullURL := "http://localhost/images/create?fromImage=" + url.QueryEscape(assignment.Spec.Image)
 	pullReq, _ := http.NewRequest(http.MethodPost, pullURL, nil)
 	pullResp, err := client.Do(pullReq)
@@ -316,6 +319,21 @@ func createAgentContainer(client *http.Client, assignment workloadAssignment, lo
 	}
 	logger.Info("created reconciled workload container", "server_id", assignment.ServerID, "generation", assignment.Generation)
 	return nil
+}
+
+func normalizeAgentInstancePermissions(root string) error {
+	return filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
+		if entry.IsDir() {
+			return os.Chmod(path, 0o777)
+		}
+		return os.Chmod(path, 0o666)
+	})
 }
 
 func startAgentContainer(client *http.Client, name string) error {

--- a/apps/agent/reconcile_test.go
+++ b/apps/agent/reconcile_test.go
@@ -4,6 +4,8 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -56,5 +58,36 @@ func TestAgentDataBindPathsSupportsWholeDataDirectoryMount(t *testing.T) {
 	}
 	if host != "/var/lib/gamepanel/instances/server-1" || container != "/data" {
 		t.Fatalf("unexpected bind paths: %s:%s", host, container)
+	}
+}
+
+func TestNormalizeAgentInstancePermissions(t *testing.T) {
+	root := t.TempDir()
+	worlds := filepath.Join(root, "Worlds")
+	if err := os.Mkdir(worlds, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	world := filepath.Join(worlds, "world.wld")
+	if err := os.WriteFile(world, []byte("world"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := normalizeAgentInstancePermissions(root); err != nil {
+		t.Fatal(err)
+	}
+
+	worldsInfo, err := os.Stat(worlds)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := worldsInfo.Mode().Perm(); got != 0o777 {
+		t.Fatalf("expected Worlds mode 0777, got %04o", got)
+	}
+	worldInfo, err := os.Stat(world)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := worldInfo.Mode().Perm(); got != 0o666 {
+		t.Fatalf("expected world mode 0666, got %04o", got)
 	}
 }


### PR DESCRIPTION
## Root cause
The assignment reconciler rewrote generated config permissions but did not normalize existing world files before recreating a container. Terraria then failed with UnauthorizedAccessException after the first reconcile.

## Fix
- recursively restore writable directory/file modes inside the isolated instance directory
- ignore symlinks while normalizing permissions
- add a regression test for existing Worlds data

## Verification
- GOFLAGS=-mod=vendor go test ./apps/agent
- game server recovered after applying the equivalent permission repair on um773