### PR TITLE
fix: harden worker reconciliation

### DIFF
--- a/apps/agent/main.go
+++ b/apps/agent/main.go
@@ -19,6 +19,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type AgentConfig struct {
@@ -49,7 +51,7 @@ type HeartbeatPayload struct {
 	PingLatencyMS   int     `json:"pingLatencyMs"`
 }
 
-const AgentVersion = "v0.4.47"
+const AgentVersion = "v0.4.48"
 
 func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
@@ -74,7 +76,7 @@ func main() {
 		fmt.Println("    -e MASTER_URL=\"https://your-panel.com\" \\")
 		fmt.Println("    -e AGENT_TOKEN=\"gpl_agent_xxxx\" \\")
 		fmt.Println("    -v /var/run/docker.sock:/var/run/docker.sock \\")
-		fmt.Println("    smartcat99999/game-panel-lite-agent:v0.4.47")
+		fmt.Println("    smartcat99999/game-panel-lite-agent:v0.4.48")
 		os.Exit(1)
 	}
 
@@ -345,18 +347,7 @@ func startLogStreamerLoop(client *http.Client, cfg AgentConfig, logger *slog.Log
 		resp.Body.Close()
 
 		for _, c := range containers {
-			var serverID string
-			for _, name := range c.Names {
-				clean := strings.TrimPrefix(name, "/")
-				if strings.HasPrefix(clean, "gamepanel-") {
-					serverID = strings.TrimPrefix(clean, "gamepanel-")
-					break
-				}
-				if len(clean) == 36 && strings.Count(clean, "-") == 4 {
-					serverID = clean
-					break
-				}
-			}
+			serverID := serverIDFromContainerNames(c.Names)
 			if serverID == "" {
 				continue
 			}
@@ -401,6 +392,20 @@ func startLogStreamerLoop(client *http.Client, cfg AgentConfig, logger *slog.Log
 			}
 		}
 	}
+}
+
+func serverIDFromContainerNames(names []string) string {
+	for _, name := range names {
+		clean := strings.TrimPrefix(name, "/")
+		candidate := clean
+		if strings.HasPrefix(clean, "gamepanel-") {
+			candidate = strings.TrimPrefix(clean, "gamepanel-")
+		}
+		if uuid.Validate(candidate) == nil {
+			return candidate
+		}
+	}
+	return ""
 }
 
 func cleanDockerLogLines(data []byte) []string {

--- a/apps/agent/reconcile.go
+++ b/apps/agent/reconcile.go
@@ -41,11 +41,12 @@ type agentWorkloadSpec struct {
 }
 
 type workloadObservation struct {
-	ObservedGeneration int       `json:"observedGeneration"`
-	RuntimeID          string    `json:"runtimeId,omitempty"`
-	ActualState        string    `json:"actualState"`
-	LastError          string    `json:"lastError,omitempty"`
-	ObservedAt         time.Time `json:"observedAt"`
+	ObservedGeneration       int       `json:"observedGeneration"`
+	RuntimeID                string    `json:"runtimeId,omitempty"`
+	ActualState              string    `json:"actualState"`
+	LastError                string    `json:"lastError,omitempty"`
+	ReconcileDurationSeconds float64   `json:"reconcileDurationSeconds"`
+	ObservedAt               time.Time `json:"observedAt"`
 }
 
 type dockerContainerState struct {
@@ -89,8 +90,12 @@ func reconcileWorkload(assignment workloadAssignment, logger *slog.Logger) workl
 	return reconcileWorkloadWithClient(assignment, logger, newDockerSocketClient(90*time.Second))
 }
 
-func reconcileWorkloadWithClient(assignment workloadAssignment, logger *slog.Logger, dockerClient *http.Client) workloadObservation {
-	observation := workloadObservation{
+func reconcileWorkloadWithClient(assignment workloadAssignment, logger *slog.Logger, dockerClient *http.Client) (observation workloadObservation) {
+	startedAt := time.Now()
+	defer func() {
+		observation.ReconcileDurationSeconds = time.Since(startedAt).Seconds()
+	}()
+	observation = workloadObservation{
 		ObservedGeneration: assignment.Generation,
 		ActualState:        "unknown",
 		ObservedAt:         time.Now().UTC(),
@@ -117,9 +122,13 @@ func reconcileWorkloadWithClient(assignment workloadAssignment, logger *slog.Log
 				observation.LastError = err.Error()
 				return observation
 			}
+			state, err = inspectAgentContainer(dockerClient, containerName)
+			if err != nil {
+				observation.LastError = err.Error()
+				return observation
+			}
 		}
-		state, err = inspectAgentContainer(dockerClient, containerName)
-		if err == nil && !state.Running {
+		if !state.Running {
 			err = startAgentContainer(dockerClient, containerName)
 		}
 	case "stopped":

--- a/apps/agent/reconcile_test.go
+++ b/apps/agent/reconcile_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -89,5 +90,61 @@ func TestNormalizeAgentInstancePermissions(t *testing.T) {
 	}
 	if got := worldInfo.Mode().Perm(); got != 0o666 {
 		t.Fatalf("expected world mode 0666, got %04o", got)
+	}
+}
+
+func TestServerIDFromContainerNamesIgnoresAgentContainers(t *testing.T) {
+	for _, names := range [][]string{
+		{"/gamepanel-agent"},
+		{"/gamepanel-agent-backup-20260828"},
+	} {
+		if got := serverIDFromContainerNames(names); got != "" {
+			t.Fatalf("expected agent container %v to be ignored, got %q", names, got)
+		}
+	}
+	const serverID = "f2b4c3b6-86bb-448a-b6b1-0745cf1c12c7"
+	if got := serverIDFromContainerNames([]string{"/gamepanel-" + serverID}); got != serverID {
+		t.Fatalf("expected game server id %q, got %q", serverID, got)
+	}
+}
+
+func TestReportWorkloadObservationRecoversOnNextAttempt(t *testing.T) {
+	attempts := 0
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		attempts++
+		if attempts == 1 {
+			return nil, errors.New("master unavailable")
+		}
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"acceptedGeneration":2}`)), Header: make(http.Header)}, nil
+	})}
+	assignment := workloadAssignment{UID: "uid-1", ServerID: "server-1", NodeID: "node-1", Generation: 2}
+	observation := workloadObservation{ObservedGeneration: 2, ActualState: "running"}
+	if err := reportWorkloadObservation(client, AgentConfig{MasterURL: "http://master", Token: "token"}, assignment, observation); err == nil {
+		t.Fatal("expected first report to fail while master is unavailable")
+	}
+	if err := reportWorkloadObservation(client, AgentConfig{MasterURL: "http://master", Token: "token"}, assignment, observation); err != nil {
+		t.Fatalf("expected next reconcile report to recover: %v", err)
+	}
+}
+
+func TestReconcileRunningAssignmentIsIdempotentAfterAgentRestart(t *testing.T) {
+	requests := 0
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests++
+		if req.Method != http.MethodGet || !strings.HasSuffix(req.URL.Path, "/json") {
+			t.Fatalf("unexpected mutation during steady-state reconcile: %s %s", req.Method, req.URL.Path)
+		}
+		body := `{"Id":"container-1","State":{"Running":true},"Config":{"Labels":{"io.gamepanel.assignment-uid":"uid-1","io.gamepanel.generation":"2"}}}`
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}, nil
+	})}
+	assignment := workloadAssignment{UID: "uid-1", ServerID: "server-1", NodeID: "node-1", Generation: 2, DesiredState: "running"}
+	for i := 0; i < 2; i++ {
+		observation := reconcileWorkloadWithClient(assignment, slog.Default(), client)
+		if observation.LastError != "" || observation.ActualState != "running" {
+			t.Fatalf("unexpected observation after restart pass %d: %+v", i+1, observation)
+		}
+	}
+	if requests != 4 {
+		t.Fatalf("expected two read-only inspections per pass, got %d requests", requests)
 	}
 }

--- a/apps/api/internal/domain/models.go
+++ b/apps/api/internal/domain/models.go
@@ -441,18 +441,19 @@ type WorkloadAssignment struct {
 // WorkloadObservation is the worker's latest observation of real runtime state.
 // AssignmentUID fences stale reports from earlier placements of the same server.
 type WorkloadObservation struct {
-	ID                 string            `json:"id" gorm:"primaryKey"`
-	AssignmentUID      string            `json:"assignmentUid" gorm:"uniqueIndex"`
-	ServerID           string            `json:"serverId" gorm:"index"`
-	NodeID             string            `json:"nodeId" gorm:"index"`
-	ObservedGeneration int               `json:"observedGeneration"`
-	RuntimeID          string            `json:"runtimeId,omitempty"`
-	ActualState        ServerActualState `json:"actualState"`
-	Conditions         []ServerCondition `json:"conditions,omitempty" gorm:"serializer:json"`
-	LastError          string            `json:"lastError,omitempty"`
-	ObservedAt         time.Time         `json:"observedAt"`
-	CreatedAt          time.Time         `json:"createdAt"`
-	UpdatedAt          time.Time         `json:"updatedAt"`
+	ID                       string            `json:"id" gorm:"primaryKey"`
+	AssignmentUID            string            `json:"assignmentUid" gorm:"uniqueIndex"`
+	ServerID                 string            `json:"serverId" gorm:"index"`
+	NodeID                   string            `json:"nodeId" gorm:"index"`
+	ObservedGeneration       int               `json:"observedGeneration"`
+	RuntimeID                string            `json:"runtimeId,omitempty"`
+	ActualState              ServerActualState `json:"actualState"`
+	Conditions               []ServerCondition `json:"conditions,omitempty" gorm:"serializer:json"`
+	LastError                string            `json:"lastError,omitempty"`
+	ReconcileDurationSeconds float64           `json:"reconcileDurationSeconds" gorm:"-"`
+	ObservedAt               time.Time         `json:"observedAt"`
+	CreatedAt                time.Time         `json:"createdAt"`
+	UpdatedAt                time.Time         `json:"updatedAt"`
 }
 
 type AdminAccount struct {

--- a/apps/api/internal/http/agent_assignments_test.go
+++ b/apps/api/internal/http/agent_assignments_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	stdhttp "net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -52,7 +53,7 @@ func TestAgentAssignmentsRequireOwningNodeToken(t *testing.T) {
 		t.Fatalf("unexpected assignments: %v %+v", err, assignments)
 	}
 
-	statusBody := []byte(`{"observedGeneration":1,"actualState":"running"}`)
+	statusBody := []byte(`{"observedGeneration":1,"actualState":"running","reconcileDurationSeconds":0.25}`)
 	forbiddenRequest := httptest.NewRequest(stdhttp.MethodPost, "/api/agent/assignments/uid-1/status", bytes.NewReader(statusBody))
 	forbiddenRequest.Header.Set("X-Node-Token", "token-b")
 	forbiddenResponse := httptest.NewRecorder()
@@ -71,5 +72,18 @@ func TestAgentAssignmentsRequireOwningNodeToken(t *testing.T) {
 	observation, err := db.GetWorkloadObservation(context.Background(), assignment.UID)
 	if err != nil || observation.NodeID != "node-a" || observation.ActualState != domain.ActualRunning {
 		t.Fatalf("unexpected stored observation: %v %+v", err, observation)
+	}
+
+	metricsResponse := httptest.NewRecorder()
+	router.ServeHTTP(metricsResponse, httptest.NewRequest(stdhttp.MethodGet, "/metrics", nil))
+	metricsBody := metricsResponse.Body.String()
+	for _, expected := range []string{
+		`gamepanel_worker_reconcile_backlog{node_id="node-a"} 1`,
+		`gamepanel_worker_reconcile_duration_seconds_count{node_id="node-a"} 1`,
+		`gamepanel_worker_generation_lag{node_id="node-a",server_id="server-1"} 0`,
+	} {
+		if !strings.Contains(metricsBody, expected) {
+			t.Fatalf("expected agent metric %q, got:\n%s", expected, metricsBody)
+		}
 	}
 }

--- a/apps/api/internal/http/node_handlers.go
+++ b/apps/api/internal/http/node_handlers.go
@@ -272,6 +272,7 @@ func (h *Handler) agentRegister(w http.ResponseWriter, r *http.Request) {
 	node.Status = "online"
 	node.LastHeartbeat = time.Now().UTC()
 	node.UpdatedAt = time.Now().UTC()
+	h.apiMetrics.ObserveAgentHeartbeat(node.ID, node.LastHeartbeat)
 
 	if err := h.store.UpdateComputeNode(r.Context(), &node); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to update node status: "+err.Error())
@@ -324,6 +325,7 @@ func (h *Handler) agentHeartbeat(w http.ResponseWriter, r *http.Request) {
 	node.Status = "online"
 	node.LastHeartbeat = time.Now().UTC()
 	node.UpdatedAt = time.Now().UTC()
+	h.apiMetrics.ObserveAgentHeartbeat(node.ID, node.LastHeartbeat)
 
 	_ = h.store.UpdateComputeNode(r.Context(), &node)
 
@@ -492,6 +494,14 @@ func (h *Handler) listAgentAssignments(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to list workload assignments")
 		return
 	}
+	pending := 0
+	for _, assignment := range assignments {
+		observation, observationErr := h.store.GetWorkloadObservation(r.Context(), assignment.UID)
+		if observationErr != nil || observation.ObservedGeneration < assignment.Generation {
+			pending++
+		}
+	}
+	h.apiMetrics.SetWorkloadBacklog(node.ID, pending)
 	writeJSON(w, http.StatusOK, assignments)
 }
 
@@ -518,6 +528,10 @@ func (h *Handler) reportAgentAssignmentStatus(w http.ResponseWriter, r *http.Req
 		writeError(w, http.StatusConflict, "observation generation is newer than assignment")
 		return
 	}
+	if observation.ReconcileDurationSeconds < 0 || observation.ReconcileDurationSeconds > 600 {
+		writeError(w, http.StatusBadRequest, "invalid reconcile duration")
+		return
+	}
 	now := time.Now().UTC()
 	observation.ID = uuid.NewString()
 	observation.AssignmentUID = assignment.UID
@@ -532,6 +546,13 @@ func (h *Handler) reportAgentAssignmentStatus(w http.ResponseWriter, r *http.Req
 		writeError(w, http.StatusInternalServerError, "failed to persist workload observation")
 		return
 	}
+	h.apiMetrics.ObserveWorkloadReconcile(
+		node.ID,
+		assignment.ServerID,
+		time.Duration(observation.ReconcileDurationSeconds*float64(time.Second)),
+		assignment.Generation-observation.ObservedGeneration,
+		observation.LastError != "",
+	)
 	writeJSON(w, http.StatusOK, map[string]int{"acceptedGeneration": observation.ObservedGeneration})
 }
 

--- a/apps/api/internal/metrics/registry.go
+++ b/apps/api/internal/metrics/registry.go
@@ -31,6 +31,12 @@ type Registry struct {
 
 	prometheusDuration map[string]*histogram
 	prometheusErrors   map[string]float64
+
+	workerHeartbeat     map[string]float64
+	workerBacklog       map[string]float64
+	workerDuration      map[string]*histogram
+	workerFailures      map[string]float64
+	workerGenerationLag map[string]float64
 }
 
 type histogram struct {
@@ -41,15 +47,20 @@ type histogram struct {
 
 func NewRegistry() *Registry {
 	return &Registry{
-		httpRequests:       map[string]float64{},
-		httpDuration:       map[string]*histogram{},
-		httpInFlight:       map[string]float64{},
-		sseConnections:     map[string]float64{},
-		sseEvents:          map[string]float64{},
-		dbDuration:         map[string]*histogram{},
-		dbErrors:           map[string]float64{},
-		prometheusDuration: map[string]*histogram{},
-		prometheusErrors:   map[string]float64{},
+		httpRequests:        map[string]float64{},
+		httpDuration:        map[string]*histogram{},
+		httpInFlight:        map[string]float64{},
+		sseConnections:      map[string]float64{},
+		sseEvents:           map[string]float64{},
+		dbDuration:          map[string]*histogram{},
+		dbErrors:            map[string]float64{},
+		prometheusDuration:  map[string]*histogram{},
+		prometheusErrors:    map[string]float64{},
+		workerHeartbeat:     map[string]float64{},
+		workerBacklog:       map[string]float64{},
+		workerDuration:      map[string]*histogram{},
+		workerFailures:      map[string]float64{},
+		workerGenerationLag: map[string]float64{},
 	}
 }
 
@@ -97,6 +108,28 @@ func (r *Registry) ObserveDBQuery(operation string, elapsed time.Duration, err e
 	}
 }
 
+func (r *Registry) ObserveAgentHeartbeat(nodeID string, at time.Time) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.workerHeartbeat[labelKey(nodeID)] = float64(at.Unix())
+}
+
+func (r *Registry) SetWorkloadBacklog(nodeID string, pending int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.workerBacklog[labelKey(nodeID)] = float64(pending)
+}
+
+func (r *Registry) ObserveWorkloadReconcile(nodeID, serverID string, elapsed time.Duration, generationLag int, failed bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.histogramLocked(r.workerDuration, labelKey(nodeID)).observe(elapsed.Seconds())
+	r.workerGenerationLag[labelKey(nodeID, serverID)] = float64(max(generationLag, 0))
+	if failed {
+		r.workerFailures[labelKey(nodeID)]++
+	}
+}
+
 func (r *Registry) AddSSEConnection(stream string, delta float64) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -125,6 +158,11 @@ func (r *Registry) PrometheusText() string {
 	writeCounterVec(&b, "gamepanel_api_db_errors_total", "Database errors by operation.", []string{"operation"}, r.dbErrors)
 	writeHistogramVec(&b, "gamepanel_api_prometheus_query_duration_seconds", "Prometheus query duration in seconds.", []string{"query_type"}, r.prometheusDuration)
 	writeCounterVec(&b, "gamepanel_api_prometheus_query_errors_total", "Prometheus query errors by query type.", []string{"query_type"}, r.prometheusErrors)
+	writeGaugeVec(&b, "gamepanel_worker_last_heartbeat_timestamp_seconds", "Unix timestamp of the last accepted worker heartbeat.", []string{"node_id"}, r.workerHeartbeat)
+	writeGaugeVec(&b, "gamepanel_worker_reconcile_backlog", "Assignments whose generation has not yet been observed by the worker.", []string{"node_id"}, r.workerBacklog)
+	writeHistogramVec(&b, "gamepanel_worker_reconcile_duration_seconds", "Worker workload reconcile duration in seconds.", []string{"node_id"}, r.workerDuration)
+	writeCounterVec(&b, "gamepanel_worker_reconcile_failures_total", "Failed worker workload reconcile attempts.", []string{"node_id"}, r.workerFailures)
+	writeGaugeVec(&b, "gamepanel_worker_generation_lag", "Difference between desired and observed workload generations.", []string{"node_id", "server_id"}, r.workerGenerationLag)
 	return b.String()
 }
 

--- a/apps/api/internal/metrics/registry_test.go
+++ b/apps/api/internal/metrics/registry_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -24,6 +25,26 @@ func TestMiddlewareUsesRoutePatternLabels(t *testing.T) {
 	}
 	if strings.Contains(body, "example-id") {
 		t.Fatalf("route label leaked concrete id:\n%s", body)
+	}
+}
+
+func TestWorkloadReconcileMetrics(t *testing.T) {
+	registry := NewRegistry()
+	registry.ObserveAgentHeartbeat("node-1", time.Unix(100, 0))
+	registry.SetWorkloadBacklog("node-1", 2)
+	registry.ObserveWorkloadReconcile("node-1", "server-1", 250*time.Millisecond, 1, true)
+
+	body := registry.PrometheusText()
+	for _, expected := range []string{
+		`gamepanel_worker_last_heartbeat_timestamp_seconds{node_id="node-1"} 100`,
+		`gamepanel_worker_reconcile_backlog{node_id="node-1"} 2`,
+		`gamepanel_worker_reconcile_duration_seconds_count{node_id="node-1"} 1`,
+		`gamepanel_worker_reconcile_failures_total{node_id="node-1"} 1`,
+		`gamepanel_worker_generation_lag{node_id="node-1",server_id="server-1"} 1`,
+	} {
+		if !strings.Contains(body, expected) {
+			t.Fatalf("expected worker metric %q, got:\n%s", expected, body)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- ignore agent and rollback containers in game server log discovery by accepting only UUID-backed server containers
- publish worker heartbeat, reconcile backlog, duration, failure, and generation-lag metrics from the control plane
- report reconcile duration from agents and preserve idempotent steady-state behavior
- cover master disconnect recovery and agent restart convergence

## Verification
- go test ./...
- go vet ./...
- go build ./...
- pnpm --dir apps/web lint
- pnpm --dir apps/web typecheck
- pnpm --dir apps/web test (107 tests)
- pnpm --dir apps/web build
- git diff --check