### PR TITLE
build: use vendor for all Go images

### DIFF
--- a/docker/exporter/Dockerfile
+++ b/docker/exporter/Dockerfile
@@ -3,11 +3,11 @@ FROM golang:1.25-bookworm AS builder
 WORKDIR /src
 
 COPY go.mod go.sum ./
-RUN go mod download
+COPY vendor ./vendor
 
 COPY apps/api ./apps/api
 
-RUN CGO_ENABLED=1 GOOS=linux go build -o /out/gamepanel-exporter ./apps/api/cmd/gamepanel-exporter
+RUN CGO_ENABLED=1 GOOS=linux go build -mod=vendor -o /out/gamepanel-exporter ./apps/api/cmd/gamepanel-exporter
 
 FROM debian:bookworm-slim AS runner
 

--- a/docker/updater/Dockerfile
+++ b/docker/updater/Dockerfile
@@ -2,9 +2,9 @@ FROM golang:1.25-bookworm AS builder
 
 WORKDIR /src
 COPY go.mod go.sum ./
-RUN go mod download
+COPY vendor ./vendor
 COPY apps/updater ./apps/updater
-RUN CGO_ENABLED=0 GOOS=linux go build -o /out/gamepanel-updater ./apps/updater/cmd/server
+RUN CGO_ENABLED=0 GOOS=linux go build -mod=vendor -o /out/gamepanel-updater ./apps/updater/cmd/server
 
 FROM docker:28-cli
 RUN docker compose version


### PR DESCRIPTION
## Summary
- build exporter from the committed vendor tree
- build updater from the committed vendor tree
- remove network-dependent Go module downloads from all production Go image builds

## Verification
- all Go Dockerfiles now use -mod=vendor
- git diff --check