### PR TITLE
fix: mount worker data into agent

### DIFF
--- a/apps/agent/main.go
+++ b/apps/agent/main.go
@@ -76,6 +76,7 @@ func main() {
 		fmt.Println("    -e MASTER_URL=\"https://your-panel.com\" \\")
 		fmt.Println("    -e AGENT_TOKEN=\"gpl_agent_xxxx\" \\")
 		fmt.Println("    -v /var/run/docker.sock:/var/run/docker.sock \\")
+		fmt.Println("    -v /var/lib/gamepanel:/var/lib/gamepanel \\")
 		fmt.Println("    smartcat99999/game-panel-lite-agent:v0.4.48")
 		os.Exit(1)
 	}

--- a/apps/api/internal/http/agent_assignments_test.go
+++ b/apps/api/internal/http/agent_assignments_test.go
@@ -87,3 +87,10 @@ func TestAgentAssignmentsRequireOwningNodeToken(t *testing.T) {
 		}
 	}
 }
+
+func TestAgentDockerCommandMountsWorkerDataDirectory(t *testing.T) {
+	command := agentDockerCommand("https://panel.example.com", "node-token")
+	if !strings.Contains(command, "-v /var/lib/gamepanel:/var/lib/gamepanel") {
+		t.Fatalf("expected worker data mount in agent command, got %q", command)
+	}
+}

--- a/apps/api/internal/http/node_handlers.go
+++ b/apps/api/internal/http/node_handlers.go
@@ -208,10 +208,7 @@ func (h *Handler) getNodeJoinCommand(w http.ResponseWriter, r *http.Request) {
 	}
 	masterURL := fmt.Sprintf("%s://%s", scheme, host)
 
-	dockerCmd := fmt.Sprintf(
-		"docker run -d --name gamepanel-agent --restart always --net=host -v /var/run/docker.sock:/var/run/docker.sock -e MASTER_URL=%s -e AGENT_TOKEN=%s smartcat99999/game-panel-lite-agent:latest",
-		masterURL, node.Token,
-	)
+	dockerCmd := agentDockerCommand(masterURL, node.Token)
 	shellCmd := fmt.Sprintf(
 		"curl -fsSL %s/install-agent.sh | sudo bash -s -- --master=%s --token=%s",
 		masterURL, masterURL, node.Token,
@@ -224,6 +221,13 @@ func (h *Handler) getNodeJoinCommand(w http.ResponseWriter, r *http.Request) {
 		DockerCommand: dockerCmd,
 		ShellCommand:  shellCmd,
 	})
+}
+
+func agentDockerCommand(masterURL, token string) string {
+	return fmt.Sprintf(
+		"docker run -d --name gamepanel-agent --restart always --net=host -v /var/run/docker.sock:/var/run/docker.sock -v /var/lib/gamepanel:/var/lib/gamepanel -e MASTER_URL=%s -e AGENT_TOKEN=%s smartcat99999/game-panel-lite-agent:latest",
+		masterURL, token,
+	)
 }
 
 func (h *Handler) agentRegister(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- mount /var/lib/gamepanel into agent containers so filesystem writes and permission normalization target the Docker host data
- update the generated node join command and CLI usage
- cover the required worker data mount

## Verification
- go test ./apps/agent ./apps/api/internal/http -run 'TestAgentDockerCommandMountsWorkerDataDirectory|TestAgentAssignmentsRequireOwningNodeToken|TestNormalizeAgentInstancePermissions'
- git diff --check