### PR TITLE
fix: enrich server mod metadata from library

### DIFF
--- a/apps/api/internal/http/mod_handlers.go
+++ b/apps/api/internal/http/mod_handlers.go
@@ -25,6 +25,11 @@ func (h *Handler) listMods(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+	mods, err = h.enrichServerModMetadata(r.Context(), mods)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
 	visible, err := h.visibleServerMods(r.Context(), server, mods)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())

--- a/apps/api/internal/http/mod_handlers_test.go
+++ b/apps/api/internal/http/mod_handlers_test.go
@@ -207,6 +207,75 @@ func TestModListsPruneMissingFiles(t *testing.T) {
 	}
 }
 
+func TestServerModListEnrichesWorkshopMetadataFromLibrary(t *testing.T) {
+	router, db, cfg := newTestRouter(t)
+	server := testServer("dst", cfg.DataDir)
+	server.GameKey = domain.GameDST
+	server.ProviderKey = domain.ProviderDST
+	createTestServer(t, db, server)
+
+	serverMod := domain.ModFile{
+		ID:          "server-workshop-mod",
+		InstanceID:  server.ID,
+		GameKey:     server.GameKey,
+		ProviderKey: server.ProviderKey,
+		FileName:    "workshop-3007715893",
+		Source:      "workshop",
+		WorkshopID:  "3007715893",
+		Title:       "Workshop 3007715893",
+		SizeBytes:   11,
+		Enabled:     false,
+		CreatedAt:   time.Now(),
+	}
+	libraryMod := domain.ModFile{
+		ID:               "library-workshop-mod",
+		InstanceID:       "unassigned",
+		GameKey:          server.GameKey,
+		ProviderKey:      server.ProviderKey,
+		FileName:         "workshop-3007715893",
+		Source:           "workshop",
+		WorkshopID:       "3007715893",
+		ModName:          "more_items_stack",
+		Title:            "更多物品堆叠/More Items Stack",
+		Description:      "Stack more items.",
+		PreviewURL:       "https://example.com/preview.png",
+		TagsJSON:         `["all_clients_require_mod"]`,
+		DependenciesJSON: `["workshop-123"]`,
+		SizeBytes:        57940,
+		Enabled:          true,
+		CreatedAt:        time.Now(),
+	}
+	if err := db.CreateMod(context.Background(), &serverMod); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.CreateMod(context.Background(), &libraryMod); err != nil {
+		t.Fatal(err)
+	}
+
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, httptest.NewRequest(stdhttp.MethodGet, "/api/servers/dst/mods", nil))
+	if response.Code != stdhttp.StatusOK {
+		t.Fatalf("expected server mod list 200, got %d: %s", response.Code, response.Body.String())
+	}
+	var mods []domain.ModFile
+	if err := json.Unmarshal(response.Body.Bytes(), &mods); err != nil {
+		t.Fatal(err)
+	}
+	if len(mods) != 1 {
+		t.Fatalf("expected one server mod, got %+v", mods)
+	}
+	got := mods[0]
+	if got.ID != serverMod.ID || got.InstanceID != server.ID || got.Enabled {
+		t.Fatalf("expected server installation state to be preserved, got %+v", got)
+	}
+	if got.Title != libraryMod.Title || got.ModName != libraryMod.ModName || got.SizeBytes != libraryMod.SizeBytes {
+		t.Fatalf("expected library display metadata, got %+v", got)
+	}
+	if !reflect.DeepEqual(got.Tags, []string{"all_clients_require_mod"}) || !reflect.DeepEqual(got.Dependencies, []string{"workshop-123"}) {
+		t.Fatalf("expected hydrated library tags and dependencies, got %+v", got)
+	}
+}
+
 func TestTModLoaderModUploadIsIdempotentForSameFile(t *testing.T) {
 	router, db, cfg := newTestRouter(t)
 	server := testServer("tmod", cfg.DataDir)

--- a/apps/api/internal/http/mod_helpers.go
+++ b/apps/api/internal/http/mod_helpers.go
@@ -718,6 +718,75 @@ func (h *Handler) visibleMods(ctx context.Context, mods []domain.ModFile) ([]dom
 	return visible, nil
 }
 
+func (h *Handler) enrichServerModMetadata(ctx context.Context, mods []domain.ModFile) ([]domain.ModFile, error) {
+	workshopIDs := make([]string, 0, len(mods))
+	seen := make(map[string]struct{}, len(mods))
+	for _, item := range mods {
+		if item.Source != "workshop" || item.WorkshopID == "" {
+			continue
+		}
+		if _, exists := seen[item.WorkshopID]; exists {
+			continue
+		}
+		seen[item.WorkshopID] = struct{}{}
+		workshopIDs = append(workshopIDs, item.WorkshopID)
+	}
+
+	libraryMods, err := h.store.ListLibraryModsByWorkshopIDs(ctx, workshopIDs)
+	if err != nil {
+		return nil, err
+	}
+	metadataByWorkshopID := make(map[string]domain.ModFile, len(libraryMods))
+	for _, item := range libraryMods {
+		metadataByWorkshopID[item.WorkshopID] = item
+	}
+	for index := range mods {
+		metadata, exists := metadataByWorkshopID[mods[index].WorkshopID]
+		if !exists {
+			continue
+		}
+		applyLibraryModMetadata(&mods[index], metadata)
+	}
+	return mods, nil
+}
+
+func applyLibraryModMetadata(item *domain.ModFile, metadata domain.ModFile) {
+	if metadata.ModName != "" {
+		item.ModName = metadata.ModName
+	}
+	if metadata.Title != "" {
+		item.Title = metadata.Title
+	}
+	if metadata.ModVersion != "" {
+		item.ModVersion = metadata.ModVersion
+	}
+	if metadata.TModVersion != "" {
+		item.TModVersion = metadata.TModVersion
+	}
+	if metadata.CreatorSteamID != "" {
+		item.CreatorSteamID = metadata.CreatorSteamID
+	}
+	if metadata.PreviewURL != "" {
+		item.PreviewURL = metadata.PreviewURL
+	}
+	if metadata.Description != "" {
+		item.Description = metadata.Description
+	}
+	if metadata.TagsJSON != "" {
+		item.TagsJSON = metadata.TagsJSON
+	}
+	if metadata.DependenciesJSON != "" {
+		item.DependenciesJSON = metadata.DependenciesJSON
+	}
+	item.Subscriptions = metadata.Subscriptions
+	item.Favorited = metadata.Favorited
+	item.Views = metadata.Views
+	item.UpdatedAtSteam = metadata.UpdatedAtSteam
+	if metadata.SizeBytes > 0 {
+		item.SizeBytes = metadata.SizeBytes
+	}
+}
+
 func (h *Handler) visibleServerMods(ctx context.Context, server domain.GameServer, mods []domain.ModFile) ([]domain.ModFile, error) {
 	visible, err := h.visibleMods(ctx, mods)
 	if err != nil {

--- a/apps/api/internal/store/store.go
+++ b/apps/api/internal/store/store.go
@@ -560,6 +560,16 @@ func (s *Store) ListMods(ctx context.Context, instanceID string) ([]domain.ModFi
 	return mods, s.db.WithContext(ctx).Where("instance_id = ?", instanceID).Order("created_at desc").Find(&mods).Error
 }
 
+func (s *Store) ListLibraryModsByWorkshopIDs(ctx context.Context, workshopIDs []string) ([]domain.ModFile, error) {
+	if len(workshopIDs) == 0 {
+		return []domain.ModFile{}, nil
+	}
+	var mods []domain.ModFile
+	return mods, s.db.WithContext(ctx).
+		Where("instance_id = ? AND workshop_id IN ?", "unassigned", workshopIDs).
+		Find(&mods).Error
+}
+
 func (s *Store) GetMod(ctx context.Context, id string) (domain.ModFile, error) {
 	var mod domain.ModFile
 	err := s.db.WithContext(ctx).First(&mod, "id = ?", id).Error


### PR DESCRIPTION
## Summary
- batch-load global Workshop metadata for server mod lists
- merge display metadata in memory while preserving instance state
- add regression coverage for existing placeholder server mod records

## Verification
- go test ./...
- go vet ./...
- git diff --check