### PR TITLE
fix: refresh nginx after control plane updates

### DIFF
--- a/scripts/manage.sh
+++ b/scripts/manage.sh
@@ -31,6 +31,8 @@ case "$ACTION" in
   update)
     docker compose "$@" pull $SERVICES
     docker compose "$@" up -d --remove-orphans --pull never $SERVICES
+    # Refresh Docker DNS resolutions after API and Web containers are replaced.
+    docker compose "$@" up -d --remove-orphans --pull never --no-deps --force-recreate nginx
     ;;
   stop)
     docker compose "$@" stop $SERVICES


### PR DESCRIPTION
## Summary
- force-recreate only the Nginx service after control-plane containers update
- refresh Docker DNS resolutions without restarting API, Web, or game server containers again
- preserve HTTP and HTTPS Compose overlays, including production-specific networks

## Verification
- `sh -n scripts/manage.sh`
- `GAMEPANEL_UPDATER_TOKEN=test docker compose -f compose.prod.yaml config --quiet`
- `GAMEPANEL_UPDATER_TOKEN=test docker compose -f compose.prod.yaml -f compose.https.yaml config --quiet`
- `git diff --check`