### PR TITLE
fix: hide management actions from viewers

### DIFF
--- a/apps/web/app/servers/[id]/page.tsx
+++ b/apps/web/app/servers/[id]/page.tsx
@@ -1113,6 +1113,7 @@ function OverviewTab({
   resource: GameServerResource;
   runtimeError: string;
 }) {
+  const { canEditSettings, canManageNodes } = usePermissions();
   const nodesQuery = useQuery({ queryKey: ["compute-nodes"], queryFn: listComputeNodes, retry: false, staleTime: 60000 });
   const nodeInfo = nodesQuery.data?.find((n) => n.id === resource.nodeId);
   const isWorker = Boolean(resource.nodeId && resource.nodeId !== "node-local");
@@ -1139,9 +1140,11 @@ function OverviewTab({
               <p className="text-[11px] text-slate-500">实例容器所在的物理/云端主机及连接路由模式</p>
             </div>
           </div>
-          <Link href="/settings" className="text-xs text-panel-green hover:underline flex items-center gap-1">
-            管理集群节点 <ExternalLink className="size-3" />
-          </Link>
+          {canManageNodes && canEditSettings ? (
+            <Link href="/settings" className="text-xs text-panel-green hover:underline flex items-center gap-1">
+              管理集群节点 <ExternalLink className="size-3" />
+            </Link>
+          ) : null}
         </div>
 
         <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">

--- a/apps/web/components/cluster-fleet-popover.tsx
+++ b/apps/web/components/cluster-fleet-popover.tsx
@@ -19,6 +19,7 @@ import {
 import { listComputeNodes, listGameServers, getObservabilityMetrics, getNodeJoinCommand, createComputeNode } from "@/lib/api";
 import { gameServerStatus } from "@/lib/game-server-resource";
 import { useI18n } from "@/lib/i18n";
+import { usePermissions } from "@/lib/permissions";
 import { cn } from "@/lib/utils";
 import { Button, Input } from "@/components/ui";
 import { TrafficTopology } from "@/components/traffic-topology";
@@ -26,6 +27,7 @@ import { TrafficTopology } from "@/components/traffic-topology";
 export function ClusterFleetPopover() {
   const { locale } = useI18n();
   const isZh = locale === "zh";
+  const { canEditSettings, canManageNodes } = usePermissions();
   const router = useRouter();
   const queryClient = useQueryClient();
 
@@ -175,14 +177,16 @@ export function ClusterFleetPopover() {
               </div>
             </div>
 
-            <Link
-              href="/settings"
-              onClick={() => setIsOpen(false)}
-              className="flex size-7 items-center justify-center rounded-lg border border-slate-800 bg-slate-900 text-slate-400 hover:border-slate-600 hover:text-white transition"
-              title={isZh ? "节点管理设置" : "Node Settings"}
-            >
-              <Settings className="size-3.5" />
-            </Link>
+            {canEditSettings ? (
+              <Link
+                href="/settings"
+                onClick={() => setIsOpen(false)}
+                className="flex size-7 items-center justify-center rounded-lg border border-slate-800 bg-slate-900 text-slate-400 hover:border-slate-600 hover:text-white transition"
+                title={isZh ? "节点管理设置" : "Node Settings"}
+              >
+                <Settings className="size-3.5" />
+              </Link>
+            ) : null}
           </div>
 
           {/* 实时系统指标条 */}
@@ -267,7 +271,7 @@ export function ClusterFleetPopover() {
 
           {/* 底部快捷操作 */}
           <div className="pt-2 border-t border-slate-800">
-            <div className="grid grid-cols-2 gap-2">
+            <div className={cn("grid gap-2", canManageNodes ? "grid-cols-2" : "grid-cols-1")}>
               <button
                 type="button"
                 onClick={() => {
@@ -280,20 +284,22 @@ export function ClusterFleetPopover() {
                 <span>{isZh ? "网络拓扑" : "Topology"}</span>
               </button>
 
-              <button
-                type="button"
-                onClick={() => {
-                  setIsOpen(false);
-                  setNewNodeName(`Worker-Node-${nodes.length}`);
-                  setNewNodeRegion("");
-                  setGeneratedJoinData(null);
-                  setJoinModalOpen(true);
-                }}
-                className="flex items-center justify-center gap-1.5 rounded-lg border border-emerald-500/40 bg-emerald-950 hover:bg-emerald-900 py-2 text-xs font-medium text-emerald-300 hover:text-white transition shadow-xs"
-              >
-                <Plus className="size-3.5" />
-                <span>{isZh ? "添加节点" : "Add Node"}</span>
-              </button>
+              {canManageNodes ? (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setIsOpen(false);
+                    setNewNodeName(`Worker-Node-${nodes.length}`);
+                    setNewNodeRegion("");
+                    setGeneratedJoinData(null);
+                    setJoinModalOpen(true);
+                  }}
+                  className="flex items-center justify-center gap-1.5 rounded-lg border border-emerald-500/40 bg-emerald-950 hover:bg-emerald-900 py-2 text-xs font-medium text-emerald-300 hover:text-white transition shadow-xs"
+                >
+                  <Plus className="size-3.5" />
+                  <span>{isZh ? "添加节点" : "Add Node"}</span>
+                </button>
+              ) : null}
             </div>
           </div>
         </div>
@@ -333,7 +339,7 @@ export function ClusterFleetPopover() {
       )}
 
       {/* Node Join Command Modal via createPortal */}
-      {mounted && joinModalOpen && createPortal(
+      {mounted && canManageNodes && joinModalOpen && createPortal(
         <div
           className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/80 backdrop-blur-md p-4 animate-in fade-in duration-200"
           onClick={(e) => {

--- a/apps/web/components/server-game-rules.tsx
+++ b/apps/web/components/server-game-rules.tsx
@@ -8,6 +8,7 @@ import { useToast } from "@/components/toast-context";
 import { useI18n } from "@/lib/i18n";
 import { updateGameServerConfig } from "@/lib/api";
 import { gameServerJoinPort } from "@/lib/game-server-resource";
+import { usePermissions } from "@/lib/permissions";
 import { cn } from "@/lib/utils";
 import type { GameServerResource } from "@/lib/types";
 
@@ -18,6 +19,7 @@ export function ServerGameRules({
 }) {
   const { locale } = useI18n();
   const isZh = locale.startsWith("zh");
+  const { canEditServerConfig } = usePermissions();
   const toast = useToast();
   const client = useQueryClient();
 
@@ -81,27 +83,31 @@ export function ServerGameRules({
           </p>
         </div>
 
-        <Button
-          type="button"
-          disabled={saveMutation.isPending}
-          onClick={() => saveMutation.mutate()}
-          className="gap-2 px-6 shrink-0"
-        >
-          <Save className="size-4" />
-          <span>{saveMutation.isPending ? (isZh ? "正在保存..." : "Saving...") : (isZh ? "保存游戏规则设定" : "Save Game Rules")}</span>
-        </Button>
+        {canEditServerConfig ? (
+          <Button
+            type="button"
+            disabled={saveMutation.isPending}
+            onClick={() => saveMutation.mutate()}
+            className="gap-2 px-6 shrink-0"
+          >
+            <Save className="size-4" />
+            <span>{saveMutation.isPending ? (isZh ? "正在保存..." : "Saving...") : (isZh ? "保存游戏规则设定" : "Save Game Rules")}</span>
+          </Button>
+        ) : null}
       </div>
 
       {/* Render based on GameKey */}
-      {gameKey === "palworld" ? (
-        <PalworldRules draft={draft} onChange={updateField} isZh={isZh} />
-      ) : gameKey === "minecraft" ? (
-        <MinecraftRules draft={draft} onChange={updateField} isZh={isZh} />
-      ) : gameKey === "dont-starve-together" || providerKey === "dont-starve-together" ? (
-        <DSTRules draft={draft} onChange={updateField} isZh={isZh} />
-      ) : (
-        <TerrariaRules draft={draft} onChange={updateField} isZh={isZh} />
-      )}
+      <fieldset disabled={!canEditServerConfig} className="min-w-0 space-y-6">
+        {gameKey === "palworld" ? (
+          <PalworldRules draft={draft} onChange={updateField} isZh={isZh} />
+        ) : gameKey === "minecraft" ? (
+          <MinecraftRules draft={draft} onChange={updateField} isZh={isZh} />
+        ) : gameKey === "dont-starve-together" || providerKey === "dont-starve-together" ? (
+          <DSTRules draft={draft} onChange={updateField} isZh={isZh} />
+        ) : (
+          <TerrariaRules draft={draft} onChange={updateField} isZh={isZh} />
+        )}
+      </fieldset>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- keep game rules visible but read-only for viewer accounts and hide the save action
- hide the server-detail cluster management link without node/settings permissions
- hide fleet settings and add-node actions from users without the corresponding permissions
- prevent the add-node modal from rendering without node management permission

## Root cause
The affected components rendered management controls without consuming the existing fine-grained permission flags. Backend authorization remained intact, but the UI exposed actions a viewer could not perform.

## Validation
- 27 frontend test files / 110 tests
- `pnpm --dir apps/web typecheck`
- `pnpm --dir apps/web lint`
- `pnpm --dir apps/web build`