### PR TITLE
feat: add DST seasonal event settings

### DIFF
--- a/apps/api/internal/domain/models.go
+++ b/apps/api/internal/domain/models.go
@@ -40,6 +40,7 @@ type ProviderCapabilities struct {
 type ProviderConfigField struct {
 	Name     string                      `json:"name"`
 	Label    string                      `json:"label"`
+	LabelEn  string                      `json:"labelEn,omitempty"`
 	Type     string                      `json:"type"`
 	Required bool                        `json:"required"`
 	Default  any                         `json:"default,omitempty"`

--- a/apps/api/internal/provider/dst/config.go
+++ b/apps/api/internal/provider/dst/config.go
@@ -77,6 +77,7 @@ func worldOptionFields(prefix string, world string) []domain.ProviderConfigField
 		fields = append(fields, domain.ProviderConfigField{
 			Name:    prefix + ".overrides." + item.Key,
 			Label:   item.Label,
+			LabelEn: item.LabelEn,
 			Type:    "select",
 			Default: defaultForWorld(item, world),
 			Options: options,

--- a/apps/api/internal/provider/dst/provider_test.go
+++ b/apps/api/internal/provider/dst/provider_test.go
@@ -28,7 +28,14 @@ func TestProviderCatalogMetadata(t *testing.T) {
 		t.Fatalf("expected current DST schema to expose the complete world menu, got %d fields", got)
 	}
 	grassGekkoFound := false
+	seasonalEventCount := 0
 	for _, field := range provider.ConfigSchema() {
+		if field.Group == "dst.world.worldsettings.events" {
+			seasonalEventCount++
+			if field.LabelEn == "" {
+				t.Fatalf("seasonal event %q must expose an English label", field.Name)
+			}
+		}
 		if field.Name != "world.overrides.grassgekkos" {
 			continue
 		}
@@ -36,6 +43,9 @@ func TestProviderCatalogMetadata(t *testing.T) {
 	}
 	if !grassGekkoFound {
 		t.Fatal("expected official Chinese Grass Gekko Morphing world setting")
+	}
+	if seasonalEventCount != 13 {
+		t.Fatalf("expected 13 configurable seasonal events, got %d", seasonalEventCount)
 	}
 	for _, expected := range []string{"identity.serverName", "identity.clusterName", "identity.description", "identity.password", "identity.clusterToken", "identity.visibility", "gameplay.maxPlayers", "gameplay.gameMode", "gameplay.pvp", "gameplay.pauseWhenEmpty", "gameplay.consoleEnabled", "world.preset", "caves.enabled"} {
 		if !names[expected] {
@@ -54,6 +64,25 @@ func TestProviderCatalogMetadata(t *testing.T) {
 	}
 	if names["workshopIds"] {
 		t.Fatalf("workshop IDs should be managed from the mod library, not the config schema: %+v", provider.ConfigSchema())
+	}
+}
+
+func TestSeasonalEventsRenderAsMasterWorldOverrides(t *testing.T) {
+	lua := renderLevelDataOverrideLua("forest", "forest_default", map[string]string{
+		"specialevent":          "none",
+		"winters_feast":         "enabled",
+		"year_of_the_knight":    "enabled",
+		"year_of_the_dragonfly": "default",
+	})
+	for _, expected := range []string{
+		`specialevent = "none"`,
+		`winters_feast = "enabled"`,
+		`year_of_the_knight = "enabled"`,
+		`year_of_the_dragonfly = "default"`,
+	} {
+		if !strings.Contains(lua, expected) {
+			t.Fatalf("expected seasonal override %q, got:\n%s", expected, lua)
+		}
 	}
 }
 

--- a/apps/web/app/servers/[id]/page.tsx
+++ b/apps/web/app/servers/[id]/page.tsx
@@ -795,6 +795,7 @@ export default function ServerDetailPage() {
           {activeTab === "overview" && (
             <OverviewTab
               resource={serverResource}
+              providerFields={providerCatalog?.configSchema}
               events={visibleServerEvents}
               eventsLoading={serverEventsQuery.isLoading}
               runtimeError={runtimeErrorMessage}
@@ -850,7 +851,7 @@ export default function ServerDetailPage() {
           ) : null}
           {activeTab === "config" && (
             <div className="space-y-6">
-              <ServerGameRules server={serverResource} />
+              <ServerGameRules providerFields={providerCatalog?.configSchema} server={serverResource} />
               <ResourceLimitsCard
                 cpuPercent={statsQuery.data?.cpuPercent}
                 memoryMb={statsQuery.data?.memoryMb}
@@ -1105,11 +1106,13 @@ export default function ServerDetailPage() {
 function OverviewTab({
   events,
   eventsLoading,
+  providerFields,
   resource,
   runtimeError
 }: {
   events: MonitoringEvent[];
   eventsLoading: boolean;
+  providerFields?: ProviderConfigField[];
   resource: GameServerResource;
   runtimeError: string;
 }) {
@@ -1126,7 +1129,7 @@ function OverviewTab({
   return (
     <div className="space-y-6">
       {/* 1. Visual Game Rules & Environment */}
-      <ServerGameRules server={resource} />
+      <ServerGameRules providerFields={providerFields} server={resource} />
 
       {/* 3. Compute Node Topology Card */}
       <div className="rounded-xl border border-slate-800 bg-slate-950/40 p-4 sm:p-5">

--- a/apps/web/components/server-game-rules.tsx
+++ b/apps/web/components/server-game-rules.tsx
@@ -2,19 +2,22 @@
 
 import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { Check, Flame, KeyRound, Moon, Save, Shield, ShieldAlert, Sliders, Sparkles, Swords, Users, Zap } from "lucide-react";
+import { CalendarDays, Check, Flame, KeyRound, Moon, Save, Shield, ShieldAlert, Sliders, Sparkles, Swords, Users, Zap } from "lucide-react";
 import { Button, Input } from "@/components/ui";
 import { useToast } from "@/components/toast-context";
 import { useI18n } from "@/lib/i18n";
 import { updateGameServerConfig } from "@/lib/api";
 import { gameServerJoinPort } from "@/lib/game-server-resource";
 import { usePermissions } from "@/lib/permissions";
+import { providerConfigValue, updateProviderConfigPath } from "@/lib/provider-config";
 import { cn } from "@/lib/utils";
-import type { GameServerResource } from "@/lib/types";
+import type { GameServerResource, ProviderConfigField } from "@/lib/types";
 
 export function ServerGameRules({
+  providerFields = [],
   server
 }: {
+  providerFields?: ProviderConfigField[];
   server: GameServerResource;
 }) {
   const { locale } = useI18n();
@@ -32,19 +35,7 @@ export function ServerGameRules({
   const [draft, setDraft] = useState<Record<string, unknown>>({ ...currentConfig });
 
   const updateField = (key: string, value: unknown) => {
-    setDraft((prev) => {
-      const next = { ...prev, [key]: value };
-      if (key.includes(".")) {
-        const parts = key.split(".");
-        const parent = parts[0];
-        const child = parts[1];
-        if (parent && child) {
-          const parentObj = { ...((next[parent] ?? {}) as Record<string, unknown>), [child]: value };
-          next[parent] = parentObj;
-        }
-      }
-      return next;
-    });
+    setDraft((prev) => updateProviderConfigPath(prev, key, value));
   };
 
   const saveMutation = useMutation({
@@ -103,7 +94,7 @@ export function ServerGameRules({
         ) : gameKey === "minecraft" ? (
           <MinecraftRules draft={draft} onChange={updateField} isZh={isZh} />
         ) : gameKey === "dont-starve-together" || providerKey === "dont-starve-together" ? (
-          <DSTRules draft={draft} onChange={updateField} isZh={isZh} />
+          <DSTRules draft={draft} fields={providerFields} onChange={updateField} isZh={isZh} />
         ) : (
           <TerrariaRules draft={draft} onChange={updateField} isZh={isZh} />
         )}
@@ -555,10 +546,12 @@ function MinecraftRules({
 // -------------------------------------------------------------
 function DSTRules({
   draft,
+  fields,
   onChange,
   isZh
 }: {
   draft: Record<string, unknown>;
+  fields: ProviderConfigField[];
   onChange: (key: string, value: unknown) => void;
   isZh: boolean;
 }) {
@@ -580,6 +573,10 @@ function DSTRules({
   );
   const pvp = Boolean(draft["gameplay.pvp"] ?? gameplayObj.pvp ?? draft.pvp ?? false);
   const maxPlayers = Number(draft["gameplay.maxPlayers"] ?? gameplayObj.maxPlayers ?? draft.maxPlayers ?? 6);
+  const seasonalEventFields = fields.filter((field) => field.group === "dst.world.worldsettings.events");
+  const specialEventField = fields.find((field) => field.name === "world.overrides.specialevent");
+  const followsOfficialEvent = providerConfigValue(draft, "world.overrides.specialevent") !== "none";
+  const enabledSeasonalEvents = seasonalEventFields.filter((field) => providerConfigValue(draft, field.name) === "enabled").length;
 
   const dstModes = [
     { key: "survival", labelZh: "生存模式 (标准)", labelEn: "Survival", descZh: "死后变成鬼魂，全员死亡世界重置", descEn: "Standard DST survival" },
@@ -704,6 +701,79 @@ function DSTRules({
           </div>
         </div>
       </div>
+
+      {specialEventField && seasonalEventFields.length > 0 ? (
+        <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-5 space-y-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="flex items-start gap-2">
+              <CalendarDays className="mt-0.5 size-4 shrink-0 text-panel-gold" />
+              <div>
+                <h4 className="text-xs font-bold uppercase tracking-wider text-white">
+                  {isZh ? "季节活动" : "Seasonal Events"}
+                </h4>
+                <p className="mt-1 text-[11px] leading-relaxed text-slate-400">
+                  {isZh
+                    ? "可同时启用多个额外活动。设置应用于地面世界，保存并重启服务器后生效，无需重新生成世界。"
+                    : "Enable multiple extra events at the same time. Changes apply to the Forest world after saving and restarting the server; world regeneration is not required."}
+                </p>
+              </div>
+            </div>
+            <span className="shrink-0 rounded bg-panel-green/10 px-2 py-1 text-[10px] font-medium text-panel-green">
+              {isZh ? `已额外启用 ${enabledSeasonalEvents} 项` : `${enabledSeasonalEvents} extra enabled`}
+            </span>
+          </div>
+
+          <button
+            type="button"
+            role="switch"
+            aria-checked={followsOfficialEvent}
+            onClick={() => onChange(specialEventField.name, followsOfficialEvent ? "none" : "default")}
+            className="flex w-full items-center justify-between gap-4 rounded-lg border border-slate-800 bg-slate-950/60 px-3.5 py-3 text-left transition hover:border-slate-700"
+          >
+            <span>
+              <span className="block text-xs font-bold text-slate-200">
+                {isZh ? "跟随官方当前活动" : "Follow the current official event"}
+              </span>
+              <span className="mt-1 block text-[11px] text-slate-500">
+                {isZh ? "由当前游戏版本决定默认启用的官方活动。" : "Use the default official event included in the current game build."}
+              </span>
+            </span>
+            <span aria-hidden="true" className={cn("relative h-5 w-9 shrink-0 rounded-full transition-colors", followsOfficialEvent ? "bg-panel-green" : "bg-slate-700")}>
+              <span className={cn("absolute left-0.5 top-0.5 size-4 rounded-full bg-white transition-transform", followsOfficialEvent ? "translate-x-4" : "translate-x-0")} />
+            </span>
+          </button>
+
+          <div>
+            <p className="mb-2 text-[10px] font-bold uppercase tracking-wider text-slate-500">
+              {isZh ? "额外启用的活动（支持多选）" : "Extra events (multiple selection)"}
+            </p>
+            <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
+              {seasonalEventFields.map((field) => {
+                const enabled = providerConfigValue(draft, field.name) === "enabled";
+                return (
+                  <button
+                    key={field.name}
+                    type="button"
+                    aria-pressed={enabled}
+                    onClick={() => onChange(field.name, enabled ? "default" : "enabled")}
+                    className={cn(
+                      "flex min-h-11 items-center justify-between gap-3 rounded-lg border px-3 py-2 text-left text-xs font-semibold transition",
+                      enabled
+                        ? "border-panel-green/60 bg-panel-green/10 text-panel-green"
+                        : "border-slate-800 bg-slate-950/50 text-slate-300 hover:border-slate-700"
+                    )}
+                  >
+                    <span>{isZh ? field.label : field.labelEn ?? field.label}</span>
+                    <span className={cn("flex size-4 shrink-0 items-center justify-center rounded border", enabled ? "border-panel-green bg-panel-green text-slate-950" : "border-slate-600")}>
+                      {enabled ? <Check className="size-3" /> : null}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/lib/provider-config.test.ts
+++ b/apps/web/lib/provider-config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createDefaultProviderConfigPayload, isAdvancedProviderConfigField, isProviderFieldModified, isWorldGenerationProviderConfigField, providerConfigFieldChanged, providerConfigValue, restoreProviderConfigDefaults, updateProviderConfigPayload } from "./provider-config";
+import { createDefaultProviderConfigPayload, isAdvancedProviderConfigField, isProviderFieldModified, isWorldGenerationProviderConfigField, providerConfigFieldChanged, providerConfigValue, restoreProviderConfigDefaults, updateProviderConfigPath, updateProviderConfigPayload } from "./provider-config";
 import type { ProviderCatalog, ProviderConfigField } from "./types";
 
 const provider: ProviderCatalog = {
@@ -104,6 +104,31 @@ describe("provider config helpers", () => {
     expect(playersField).toBeDefined();
     const updated = updateProviderConfigPayload(payload, playersField!, "12");
     expect(providerConfigValue(updated, "gameplay.maxPlayers")).toBe(12);
+  });
+
+  it("updates deeply nested paths without replacing sibling world rules", () => {
+    const payload = {
+      world: {
+        preset: "forest_default",
+        overrides: {
+          grass: "often",
+          winters_feast: "default"
+        }
+      }
+    };
+
+    const updated = updateProviderConfigPath(payload, "world.overrides.winters_feast", "enabled");
+
+    expect(updated).toEqual({
+      world: {
+        preset: "forest_default",
+        overrides: {
+          grass: "often",
+          winters_feast: "enabled"
+        }
+      }
+    });
+    expect(payload.world.overrides.winters_feast).toBe("default");
   });
 
   it("keeps nested schema defaults when stored override groups are empty", () => {

--- a/apps/web/lib/provider-config.ts
+++ b/apps/web/lib/provider-config.ts
@@ -26,8 +26,16 @@ export function updateProviderConfigPayload(
   field: ProviderConfigField,
   value: string | boolean
 ): ProviderConfigPayload {
+  return updateProviderConfigPath(payload, field.name, coerceProviderFieldValue(field, value));
+}
+
+export function updateProviderConfigPath(
+  payload: ProviderConfigPayload,
+  path: string,
+  value: unknown
+): ProviderConfigPayload {
   return {
-    ...setProviderConfigValue({ ...payload }, field.name, coerceProviderFieldValue(field, value))
+    ...setProviderConfigValue({ ...payload }, path, value)
   };
 }
 

--- a/apps/web/lib/types.ts
+++ b/apps/web/lib/types.ts
@@ -19,6 +19,7 @@ export type ProviderCapabilities = {
 export type ProviderConfigField = {
   name: string;
   label: string;
+  labelEn?: string;
   type: "text" | "password" | "number" | "select" | "boolean" | string;
   required: boolean;
   default?: unknown;


### PR DESCRIPTION
## Summary
- add a dedicated DST seasonal events panel with official-event control and multi-select extras
- derive event choices and English labels from the provider schema
- preserve sibling world settings when updating deeply nested provider config

## Validation
- go test ./...
- go vet ./...
- pnpm --dir apps/web test
- pnpm --dir apps/web lint
- pnpm --dir apps/web typecheck
- pnpm --dir apps/web build