### PR TITLE
fix: unify server game configuration editing

### DIFF
--- a/apps/web/app/servers/[id]/page.tsx
+++ b/apps/web/app/servers/[id]/page.tsx
@@ -69,7 +69,7 @@ import { isWorldOrBackupEventType, showWorldAndBackupFeatures } from "@/lib/feat
 import { gameServerConfigPendingRestart, gameServerJoinPort, gameServerMode, gameServerStatus, gameServerVersion, terrariaConfigFromGameServer } from "@/lib/game-server-resource";
 import { localizeRelativeTime, useI18n, type MessageKey } from "@/lib/i18n";
 import { dstModScope, isServerAssignableMod, modDisplayName, modRuntimeState, type ModRuntimeState } from "@/lib/mod-display";
-import { createDefaultProviderConfigPayload, isWorldGenerationProviderConfigField, providerConfigFieldChanged, restoreProviderConfigDefaults, updateProviderConfigPayload, type ProviderConfigPayload } from "@/lib/provider-config";
+import { createDefaultProviderConfigPayload, isCuratedGameRuleField, isWorldGenerationProviderConfigField, providerConfigFieldChanged, restoreProviderConfigDefaults, updateProviderConfigPath, updateProviderConfigPayload, type ProviderConfigPayload } from "@/lib/provider-config";
 import { describeResourceAction, formatServerDetailError, isServerLifecyclePending, shouldRenderServerDetailTabs } from "@/lib/server-detail-actions";
 import { serverInviteText, serverJoinAddress, serverJoinPassword } from "@/lib/server-join";
 import { cn } from "@/lib/utils";
@@ -807,7 +807,6 @@ export default function ServerDetailPage() {
           {activeTab === "overview" && (
             <OverviewTab
               resource={serverResource}
-              providerFields={providerCatalog?.configSchema}
               events={visibleServerEvents}
               eventsLoading={serverEventsQuery.isLoading}
               runtimeError={runtimeErrorMessage}
@@ -863,15 +862,6 @@ export default function ServerDetailPage() {
           ) : null}
           {activeTab === "config" && (
             <div className="space-y-6">
-              <ServerGameRules providerFields={providerCatalog?.configSchema} server={serverResource} />
-              <ResourceLimitsCard
-                cpuPercent={statsQuery.data?.cpuPercent}
-                memoryMb={statsQuery.data?.memoryMb}
-                resource={serverResource}
-                restartPending={configRestart.isPending}
-                onEdit={() => setResourceDialogOpen(true)}
-                onRestart={() => setPendingConfigRestart(true)}
-              />
               <ConfigTab
                 provider={providerCatalog}
                 resource={serverResource}
@@ -882,6 +872,14 @@ export default function ServerDetailPage() {
                 onRegenerateWorld={capabilities.worldRegeneration ? () => setWorldRegenerationDialogOpen(true) : undefined}
                 onRestart={() => setPendingConfigRestart(true)}
                 onSave={(nextConfig, hostPort) => configSave.mutate({ config: nextConfig, hostPort })}
+              />
+              <ResourceLimitsCard
+                cpuPercent={statsQuery.data?.cpuPercent}
+                memoryMb={statsQuery.data?.memoryMb}
+                resource={serverResource}
+                restartPending={configRestart.isPending}
+                onEdit={() => setResourceDialogOpen(true)}
+                onRestart={() => setPendingConfigRestart(true)}
               />
             </div>
           )}
@@ -1118,13 +1116,11 @@ export default function ServerDetailPage() {
 function OverviewTab({
   events,
   eventsLoading,
-  providerFields,
   resource,
   runtimeError
 }: {
   events: MonitoringEvent[];
   eventsLoading: boolean;
-  providerFields?: ProviderConfigField[];
   resource: GameServerResource;
   runtimeError: string;
 }) {
@@ -1140,10 +1136,7 @@ function OverviewTab({
   const internalPort = resource.spec.network?.port ?? 0;
   return (
     <div className="space-y-6">
-      {/* 1. Visual Game Rules & Environment */}
-      <ServerGameRules providerFields={providerFields} server={resource} />
-
-      {/* 3. Compute Node Topology Card */}
+      {/* Compute Node Topology Card */}
       <div className="rounded-xl border border-slate-800 bg-slate-950/40 p-4 sm:p-5">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
@@ -1785,6 +1778,7 @@ function ConfigTab({
   });
   const currentProviderPayload = resourceProviderPayload;
   const providerFields = provider?.configSchema ?? [];
+  const providerEditorFields = providerFields.filter((field) => !isCuratedGameRuleField(resource.providerKey, field));
   const worldGenerationDirty = !isTerrariaProvider && providerFields.some((field) =>
     isWorldGenerationProviderConfigField(resource.providerKey, field)
       && providerConfigFieldChanged(currentProviderPayload, providerDraft, field)
@@ -1804,6 +1798,13 @@ function ConfigTab({
   const restartRequired = running && !dirty && (restartRecommended || (!worldGenerationOnlyPending && gameServerConfigPendingRestart(resource)));
   const showConfigActions = dirty || savePending || saveSuccess || restartRequired || lifecycleLocked;
   const update = <K extends keyof TerrariaConfig>(key: K, value: TerrariaConfig[K]) => setDraft((current) => ({ ...current, [key]: value }));
+  const updateGameRule = (key: string, value: unknown) => {
+    if (isTerrariaProvider) {
+      setDraft((current) => ({ ...current, [key]: value } as TerrariaConfig));
+      return;
+    }
+    setProviderDraft((current) => updateProviderConfigPath(current, key, value));
+  };
   useEffect(() => {
     if (dirty || !running || !gameServerConfigPendingRestart(resource)) {
       setRestartRecommended(false);
@@ -1830,7 +1831,6 @@ function ConfigTab({
   }, [previewOpen]);
   const secretSeed = secretSeedKeyFor(draft.seed);
   const worldEvilLabel = draft.worldEvil === "corruption" ? t("tagCorruption") : draft.worldEvil === "crimson" ? t("tagCrimson") : t("tagRandom");
-  const difficultyLabel = draft.difficulty === "journey" ? t("tagJourney") : draft.difficulty === "classic" ? t("tagClassic") : draft.difficulty === "expert" ? t("tagExpert") : t("tagMaster");
   const worldSizeLabel = draft.worldSize === "small" ? t("tagSmallWorld") : draft.worldSize === "medium" ? t("tagMediumWorld") : t("tagLargeWorld");
   const seedLabel = secretSeed
     ? terrariaSecretSeeds.find((s) => s.key === secretSeed)?.label ?? draft.seed ?? ""
@@ -1845,6 +1845,14 @@ function ConfigTab({
         onSave(isTerrariaProvider ? normalizedDraft : providerDraft, hostPortDraft);
       }
     }}>
+      <ServerGameRules
+        disabled={disabled}
+        draft={isTerrariaProvider ? (draft as unknown as Record<string, unknown>) : providerDraft}
+        onChange={updateGameRule}
+        providerFields={providerFields}
+        server={resource}
+      />
+
       <div className="rounded-lg border border-panel-line bg-slate-950/40 p-4">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
@@ -1865,9 +1873,6 @@ function ConfigTab({
                 <Field label={t("serverName")}>
                   <Input value={draft.serverName ?? ""} onChange={(event) => update("serverName", event.target.value)} disabled={disabled} />
                 </Field>
-                <Field label={t("password")}>
-                  <Input value={draft.password ?? ""} onChange={(event) => update("password", event.target.value)} disabled={disabled} />
-                </Field>
                 <Field label={t("motd")}>
                   <Input
                     type="text"
@@ -1881,9 +1886,6 @@ function ConfigTab({
                 <Field label={t("externalPort")}>
                   <Input type="number" min={1024} max={65535} value={hostPortDraft} onChange={(event) => setHostPortDraft(Number(event.target.value))} disabled={disabled} />
                 </Field>
-                <Field label={t("maxPlayers")}>
-                  <Input type="number" min={1} max={255} value={draft.maxPlayers} onChange={(event) => update("maxPlayers", Number(event.target.value))} disabled={disabled} />
-                </Field>
               </div>
             </div>
             <div className="mt-4 grid overflow-hidden rounded-md border border-panel-line bg-slate-950/40 sm:grid-cols-2 sm:divide-x sm:divide-panel-line max-sm:divide-y max-sm:divide-panel-line">
@@ -1895,7 +1897,7 @@ function ConfigTab({
           <>
             <ProviderConfigEditor
               disabled={disabled}
-              fields={provider?.configSchema ?? []}
+              fields={providerEditorFields}
               hasUnsavedWorldGenerationChanges={worldGenerationDirty}
               payload={providerDraft}
               providerKey={provider?.key ?? ""}
@@ -1923,7 +1925,6 @@ function ConfigTab({
           <ReadOnlyField label={t("gameVersion")} value={gameServerVersion(resource)} />
           <ReadOnlyField label={t("worldSize")} value={worldSizeLabel} />
           <ReadOnlyField label={t("worldEvil")} value={worldEvilLabel} />
-          <ReadOnlyField label={t("difficulty")} value={difficultyLabel} />
           <ReadOnlyField label={t("internalPort")} value={String(terrariaInternalPort)} />
           <ReadOnlyField label={t("customSeed")} value={seedLabel} help={t("worldSeedHint")} />
           {seedModeCount > 0 ? (

--- a/apps/web/components/server-game-rules.tsx
+++ b/apps/web/components/server-game-rules.tsx
@@ -1,102 +1,61 @@
 "use client";
 
-import { useState } from "react";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { CalendarDays, Check, Flame, KeyRound, Moon, Save, Shield, ShieldAlert, Sliders, Sparkles, Swords, Users, Zap } from "lucide-react";
-import { Button, Input } from "@/components/ui";
-import { useToast } from "@/components/toast-context";
+import { CalendarDays, Check, Flame, KeyRound, Moon, Shield, ShieldAlert, Sliders, Sparkles, Swords, Users, Zap } from "lucide-react";
+import { Input } from "@/components/ui";
 import { useI18n } from "@/lib/i18n";
-import { updateGameServerConfig } from "@/lib/api";
-import { gameServerJoinPort } from "@/lib/game-server-resource";
-import { usePermissions } from "@/lib/permissions";
-import { providerConfigValue, updateProviderConfigPath } from "@/lib/provider-config";
+import { providerConfigValue } from "@/lib/provider-config";
 import { cn } from "@/lib/utils";
 import type { GameServerResource, ProviderConfigField } from "@/lib/types";
 
 export function ServerGameRules({
+  disabled = false,
+  draft,
+  onChange,
   providerFields = [],
   server
 }: {
+  disabled?: boolean;
+  draft: Record<string, unknown>;
+  onChange: (key: string, value: unknown) => void;
   providerFields?: ProviderConfigField[];
   server: GameServerResource;
 }) {
   const { locale } = useI18n();
   const isZh = locale.startsWith("zh");
-  const { canEditServerConfig } = usePermissions();
-  const toast = useToast();
-  const client = useQueryClient();
 
   const gameKey = server.gameKey || "terraria";
   const providerKey = server.providerKey;
 
-  const currentConfig = (server.spec?.config ?? {}) as Record<string, unknown>;
-
-  // Form State
-  const [draft, setDraft] = useState<Record<string, unknown>>({ ...currentConfig });
-
-  const updateField = (key: string, value: unknown) => {
-    setDraft((prev) => updateProviderConfigPath(prev, key, value));
-  };
-
-  const saveMutation = useMutation({
-    mutationFn: async () => {
-      await updateGameServerConfig(server.id, draft, gameServerJoinPort(server));
-    },
-    onSuccess: async () => {
-      toast.success(
-        isZh ? "游戏房间规则已保存！" : "Game Rules Saved!",
-        isZh ? "请重启房间以使新规则完全生效" : "Restart room to apply changes."
-      );
-      await client.invalidateQueries({ queryKey: ["game-server", server.id] });
-      await client.invalidateQueries({ queryKey: ["game-servers"] });
-    },
-    onError: (err) => {
-      toast.error(isZh ? "保存失败" : "Failed to save", err instanceof Error ? err.message : "");
-    }
-  });
-
   return (
     <div className="space-y-6">
       {/* Top Banner Header */}
-      <div className="rounded-xl border border-slate-800 bg-slate-950/60 p-4 sm:p-5 flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+      <div className="rounded-xl border border-slate-800 bg-slate-950/60 p-4 sm:p-5">
         <div>
           <div className="flex items-center gap-2">
             <Sliders className="size-4 text-panel-green" />
             <h3 className="text-sm font-bold text-white tracking-tight">
-              {isZh ? "🎮 游戏规则与房间设定" : "🎮 Game Room Rules & Settings"}
+              {isZh ? "🎮 常用游戏规则" : "🎮 Common Game Rules"}
             </h3>
             <span className="rounded bg-slate-800 px-2 py-0.5 text-[10px] font-mono text-slate-300">
               {gameKey.toUpperCase()}
             </span>
           </div>
           <p className="mt-1 text-xs text-slate-400">
-            {isZh ? "调整核心游戏倍率与难度，保存后重启房间生效" : "Adjust rates & gameplay. Restart room to apply."}
+            {isZh ? "集中调整常用玩法与房间规则，修改会随本页其他配置一并保存" : "Adjust common gameplay and room rules, then save all changes together."}
           </p>
         </div>
-
-        {canEditServerConfig ? (
-          <Button
-            type="button"
-            disabled={saveMutation.isPending}
-            onClick={() => saveMutation.mutate()}
-            className="gap-2 px-6 shrink-0"
-          >
-            <Save className="size-4" />
-            <span>{saveMutation.isPending ? (isZh ? "正在保存..." : "Saving...") : (isZh ? "保存游戏规则设定" : "Save Game Rules")}</span>
-          </Button>
-        ) : null}
       </div>
 
       {/* Render based on GameKey */}
-      <fieldset disabled={!canEditServerConfig} className="min-w-0 space-y-6">
+      <fieldset disabled={disabled} className="min-w-0 space-y-6">
         {gameKey === "palworld" ? (
-          <PalworldRules draft={draft} onChange={updateField} isZh={isZh} />
+          <PalworldRules draft={draft} onChange={onChange} isZh={isZh} />
         ) : gameKey === "minecraft" ? (
-          <MinecraftRules draft={draft} onChange={updateField} isZh={isZh} />
+          <MinecraftRules draft={draft} onChange={onChange} isZh={isZh} />
         ) : gameKey === "dont-starve-together" || providerKey === "dont-starve-together" ? (
-          <DSTRules draft={draft} fields={providerFields} onChange={updateField} isZh={isZh} />
+          <DSTRules draft={draft} fields={providerFields} onChange={onChange} isZh={isZh} />
         ) : (
-          <TerrariaRules draft={draft} onChange={updateField} isZh={isZh} />
+          <TerrariaRules draft={draft} onChange={onChange} isZh={isZh} />
         )}
       </fieldset>
     </div>

--- a/apps/web/lib/provider-config.test.ts
+++ b/apps/web/lib/provider-config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createDefaultProviderConfigPayload, isAdvancedProviderConfigField, isProviderFieldModified, isWorldGenerationProviderConfigField, providerConfigFieldChanged, providerConfigValue, restoreProviderConfigDefaults, updateProviderConfigPath, updateProviderConfigPayload } from "./provider-config";
+import { createDefaultProviderConfigPayload, isAdvancedProviderConfigField, isCuratedGameRuleField, isProviderFieldModified, isWorldGenerationProviderConfigField, providerConfigFieldChanged, providerConfigValue, restoreProviderConfigDefaults, updateProviderConfigPath, updateProviderConfigPayload } from "./provider-config";
 import type { ProviderCatalog, ProviderConfigField } from "./types";
 
 const provider: ProviderCatalog = {
@@ -188,6 +188,18 @@ describe("provider config helpers", () => {
     expect(isAdvancedProviderConfigField("dont-starve-together", dstRule)).toBe(true);
     expect(isAdvancedProviderConfigField("palworld", palRate)).toBe(true);
     expect(isAdvancedProviderConfigField("palworld", palName)).toBe(false);
+  });
+
+  it("identifies fields already rendered by the curated game rules", () => {
+    expect(isCuratedGameRuleField("dont-starve-together", field({ name: "gameplay.gameMode" }))).toBe(true);
+    expect(isCuratedGameRuleField("dont-starve-together", field({
+      name: "world.overrides.winters_feast",
+      group: "dst.world.worldsettings.events"
+    }))).toBe(true);
+    expect(isCuratedGameRuleField("dont-starve-together", field({ name: "identity.serverName" }))).toBe(false);
+    expect(isCuratedGameRuleField("palworld", field({ name: "expRate" }))).toBe(true);
+    expect(isCuratedGameRuleField("palworld", field({ name: "serverName" }))).toBe(false);
+    expect(isCuratedGameRuleField("minecraft", field({ name: "difficulty" }))).toBe(true);
   });
 
   it("detects numeric and nested values that differ from schema defaults", () => {

--- a/apps/web/lib/provider-config.ts
+++ b/apps/web/lib/provider-config.ts
@@ -55,6 +55,37 @@ export function isAdvancedProviderConfigField(providerKey: string, field: Provid
   return false;
 }
 
+const curatedGameRuleFields: Record<string, ReadonlySet<string>> = {
+  "dont-starve-together": new Set([
+    "caves.enabled",
+    "gameplay.gameMode",
+    "gameplay.maxPlayers",
+    "gameplay.pauseWhenEmpty",
+    "gameplay.pvp",
+    "world.overrides.specialevent"
+  ]),
+  minecraft: new Set(["difficulty", "gameMode", "maxPlayers", "onlineMode", "whitelistEnabled"]),
+  palworld: new Set([
+    "baseCampWorkerMaxNum",
+    "captureRate",
+    "deathPenalty",
+    "eggHatchingTime",
+    "enableFastTravel",
+    "enableInvaderEnemy",
+    "expRate",
+    "maxPlayers",
+    "pvp",
+    "serverPassword"
+  ])
+};
+
+export function isCuratedGameRuleField(providerKey: string, field: ProviderConfigField): boolean {
+  if (providerKey === "dont-starve-together" && field.group === "dst.world.worldsettings.events") {
+    return true;
+  }
+  return curatedGameRuleFields[providerKey]?.has(field.name) ?? false;
+}
+
 export function isWorldGenerationProviderConfigField(providerKey: string, field: ProviderConfigField): boolean {
   if (providerKey !== "dont-starve-together") return false;
   return field.name === "world.preset"


### PR DESCRIPTION
## Summary
- keep the server lobby focused on runtime and topology information
- move curated game rules into the main configuration form with one shared draft and save action
- filter curated fields from generic provider settings to prevent duplicate controls

## Verification
- pnpm --dir apps/web test
- pnpm --dir apps/web typecheck
- pnpm --dir apps/web lint
- pnpm --dir apps/web build

No data migration or game server restart is required.